### PR TITLE
Update CMake rules to support command tensorflow/cppflow package installs

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,7 +8,7 @@ __pycache__/
 
 # Distribution / packaging
 .Python
-build/
+build*/
 build-ubuntu/
 develop-eggs/
 dist/

--- a/data/CMakeLists.txt
+++ b/data/CMakeLists.txt
@@ -24,11 +24,13 @@ set(FRAMESIMULATOR_DIR ${INAIRA_SOURCE_DIR}/frameSimulator)
 # set the integrationTest directory
 set(TEST_DIR ${INAIRA_SOURCE_DIR}/test)
 
-# set the tensorflow lib directory for Cppflow
-find_library(TENSORFLOW_LIB tensorflow HINT ${TENSORFLOW_ROOT_DIR}/lib)
-
 # C++17 requires for cppflow
 set(CMAKE_CXX_STANDARD 17)
+
+# Avoid linker warnings for tensorflow
+set(GCC_LINKER_FLAGS "-fuse-ld=gold")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${GCC_LINKER_FLAGS}")
+set(CMAKE_SHARED_LINKER_FLAGS "${CMAKE_SHARED_LINKER_FLAGS} ${GCC_LINKER_FLAGS}")
 
 # Appends the cmake/modules path inside the MAKE_MODULE_PATH variable which stores the
 # directories of additional CMake modules (ie. MacroOutOfSourceBuild.cmake):
@@ -47,9 +49,10 @@ find_package( Boost 1.41.0
 find_package(Log4CXX 0.10.0 REQUIRED)
 find_package(ZeroMQ 3.2.4 REQUIRED)
 find_package(OdinData REQUIRED)
+find_package(Tensorflow REQUIRED)
 find_package(Cppflow REQUIRED)
 
-message("Determining inaira-detector version")
+message("\nDetermining inaira-detector version")
 include(GetGitRevisionDescription)
 git_describe(GIT_DESC_STR)
 
@@ -66,8 +69,6 @@ message("-- short version: ${VERSION_SHORT}")
 
 configure_file(${COMMON_DIR}/include/version.h.in "${CMAKE_BINARY_DIR}/include/version.h")
 include_directories(${CMAKE_BINARY_DIR}/include)
-
-include_directories($ENV{HOME}/libtensorflow2/include)
 
 # Add common/include directory to include path
 include_directories(${COMMON_DIR}/include)

--- a/data/cmake/FindCppflow.cmake
+++ b/data/cmake/FindCppflow.cmake
@@ -38,9 +38,9 @@ endif()
 # Find header files
 if(CPPFLOW_ROOT_DIR)
     find_path(
-            CPPFLOW_INCLUDE_DIR cppflow.h
-            PATHS ${CPPFLOW_ROOT_DIR}
-            NO_DEFAULT_PATH
+        CPPFLOW_INCLUDE_DIR cppflow.h
+        PATHS ${CPPFLOW_ROOT_DIR}/include/cppflow
+        NO_DEFAULT_PATH
     )
 else()
     find_path(CPPFLOW_INCLUDE_DIR cppflow.h)

--- a/data/cmake/FindTensorflow.cmake
+++ b/data/cmake/FindTensorflow.cmake
@@ -1,0 +1,76 @@
+#
+# FindTensorflow.cmake
+#
+#
+# The MIT License
+#
+# Copyright (c) 2016 MIT and Intel Corporation
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in
+# all copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+# THE SOFTWARE.
+#
+# Finds the Tensorflow library. This module defines:
+#   - TENSORFLOW_INCLUDE_DIR, directory containing headers
+#   - TENSORFLOW_FOUND, whether TENSORFLOW has been found
+# Define TENSORFLOW_ROOT_DIR if Tensorflow is installed in a non-standard location.
+
+message ("\nLooking for Tensorflow headers and libraries")
+
+if (TENSORFLOW_ROOT_DIR)
+    message (STATUS "Searching Tensorflow Root Dir: ${TENSORFLOW_ROOT_DIR}")
+endif()
+
+if(TENSORFLOW_ROOT_DIR)
+
+    # Find header files
+    find_path(
+            TENSORFLOW_INCLUDE_DIR tensorflow/c/c_api.h
+            PATHS ${TENSORFLOW_ROOT_DIR}/include
+            NO_DEFAULT_PATH
+    )
+
+    # Find libraries
+    find_library(TENSORFLOW_LIBRARY
+        NAMES
+            tensorflow
+        PATHS
+            ${TENSORFLOW_ROOT_DIR}/lib
+    )
+    find_library(TENSORFLOW_FRAMEWORK_LIBRARY
+        NAMES
+            tensorflow_framework
+        PATHS
+            ${TENSORFLOW_ROOT_DIR}/lib
+    )
+
+    endif()
+
+include(FindPackageHandleStandardArgs)
+
+find_package_handle_standard_args(TENSORFLOW
+    DEFAULT_MSG
+    TENSORFLOW_INCLUDE_DIR
+    TENSORFLOW_LIBRARY
+    TENSORFLOW_FRAMEWORK_LIBRARY
+)
+
+if (TENSORFLOW_FOUND)
+    set(TENSORFLOW_LIBRARIES ${TENSORFLOW_LIBRARY} ${TENSORFLOW_FRAMEWORK_LIBRARY})
+    message(STATUS "Include directory: ${TENSORFLOW_INCLUDE_DIR}")
+    message(STATUS "Libararies: ${TENSORFLOW_LIBRARIES}")
+endif()

--- a/data/config/CMakeLists.txt
+++ b/data/config/CMakeLists.txt
@@ -3,8 +3,9 @@ file(GLOB CONFIG_FILES
   *.xml
   *.json
   )
-  
-message(STATUS "Config files: ${CONFIG_FILES}")
+
+message("\nSearching for configuration files")
+message(STATUS "Config files found: ${CONFIG_FILES}")
 
 set(CONFIG_INSTALL_DIR "${CMAKE_INSTALL_PREFIX}/config/data")
 message(STATUS "Config install dir : ${CONFIG_INSTALL_DIR}")

--- a/data/frameProcessor/src/CMakeLists.txt
+++ b/data/frameProcessor/src/CMakeLists.txt
@@ -4,17 +4,15 @@ ADD_DEFINITIONS(-DBOOST_TEST_DYN_LINK)
 
 include_directories(${FRAMEPROCESSOR_DIR}/include ${ODINDATA_INCLUDE_DIRS}
 	${Boost_INCLUDE_DIRS} ${LOG4CXX_INCLUDE_DIRS}/.. ${ZEROMQ_INCLUDE_DIRS}
-	${CPPFLOW_INCLUDE_DIR} ~/libtensorflow2)
+	${CPPFLOW_INCLUDE_DIR} ${TENSORFLOW_INCLUDE_DIR})
 
-# find_library(TENSORFLOW_LIB tensorflow HINT ~/libtensorflow2/lib)
-message(STATUS "Tensorflow ${TENSORFLOW_LIB}")
 # Add Library for each Inaira Plugin
 add_library(InairaMLPlugin SHARED InairaMLPlugin.cpp InairaMLCppflow.cpp)
 # add_library(InairaMLCppflow SHARED InairaMLCppflow.cpp)
 # add_library(InairaMLFramework SHARED InairaMLFramework.cpp)
 
-target_include_directories(InairaMLPlugin PRIVATE ../../include $ENV{HOME}/libtensorflow2/include)
-target_link_libraries (InairaMLPlugin "${TENSORFLOW_LIB}")
+target_include_directories(InairaMLPlugin PRIVATE ../../include ${TENSORFLOW_INCLUDE_DIR})
+target_link_libraries (InairaMLPlugin "${TENSORFLOW_LIBRARIES}")
 
 install(TARGETS InairaMLPlugin LIBRARY DESTINATION lib)
 # install(TARGETS InairaMLCppflow LIBRARY DESTINATION lib)


### PR DESCRIPTION
This PR adjusts the CMake rules for tensorflow and cppflow to cope with those packages being made available to the project from common installations rather than at specific locations in the user's home directory.

Closes #6