### PR TITLE
Implement frameReceiver decoder for the PCO camera

### DIFF
--- a/data/config/pco_camera_fp.json
+++ b/data/config/pco_camera_fp.json
@@ -64,7 +64,9 @@
     },
     {
         "liveview": {
-            "live_view_socket_addr":"tcp://127.0.0.1:5020"
+            "frame_frequency": 0,
+            "per_second": 1,
+            "live_view_socket_addr":"tcp://*:5020"
         }
     },
     {

--- a/data/config/pco_camera_fr.json
+++ b/data/config/pco_camera_fr.json
@@ -6,7 +6,7 @@
     "frame_release_endpoint": "tcp://127.0.0.1:5002",
     "shared_buffer_name": "PcoCameraBuffer",
     "rx_type": "cameralink",
-    "max_buffer_mem": 840000000,
+    "max_buffer_mem": 8000000000,
     "decoder_path": "./lib",
     "decoder_type": "PcoCameraLink",
     "decoder_config": {

--- a/data/frameReceiver/include/ParamContainer.h
+++ b/data/frameReceiver/include/ParamContainer.h
@@ -1,5 +1,5 @@
 /*!
- * ParamContainer.h - parameter container class with JSON encoding/decoding
+ * ParamContainer.h - abstract parameter container class with JSON encoding/decoding
  *
  * Created on: Oct 7, 2021
  *     Author: Tim Nicholls, STFC Detector Systems Software Group
@@ -81,18 +81,27 @@ class ParamContainer
         //! Use the RapidJSON Document type throughout
         typedef rapidjson::Document Document;
 
+        //! Default constructor
+        ParamContainer() {};
+
+        //! Copy constructor
+        ParamContainer(const ParamContainer& container);
+
         //! Encodes the parameter container to a JSON-formatted string
         std::string encode(void);
 
         //! Encodes the parameter container into an existing document, using the specified path
         //! as a prefix for all parameter paths
-        void encode(ParamContainer::Document& doc_obj, std::string prefix_path = std::string());
+        void encode(ParamContainer::Document& doc_obj, std::string prefix_path = std::string()) const;
 
         //! Updates the values of parameters from the specified JSON-formatted string
         void update(std::string json);
 
         //! Updates the values of the parameters from the specified JSON-formatted character array
         void update(const char* json);
+
+        //! Updates the values of the parameters from the specified parameter container
+        void update(const ParamContainer& container);
 
         //! Updates the values of the parameters from the specified JSON document
         void update(ParamContainer::Document& doc_obj);
@@ -235,6 +244,9 @@ class ParamContainer
 
     private:
 
+        //! Bind parameters - virtual method which must be defined in derived classes
+        virtual void bind_params(void) = 0;
+
         //! Sets the value of a parameter.
         //!
         //! This private template method is used by the param_set method to set the value of a
@@ -267,7 +279,7 @@ class ParamContainer
         //! \param path - reference to path string
         //! \return valid pointer path string
 
-        inline const std::string pointer_path(const std::string& path)
+        inline const std::string pointer_path(const std::string& path) const
         {
             // Set the pointer to the specified path
             std::string pointer_path(path);

--- a/data/frameReceiver/include/ParamContainer.h
+++ b/data/frameReceiver/include/ParamContainer.h
@@ -1,3 +1,10 @@
+/*!
+ * ParamContainer.h - parameter container class with JSON encoding/decoding
+ *
+ * Created on: Oct 7, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
 #ifndef PARAMCONTAINER_H_
 #define PARAMCONTAINER_H_
 
@@ -8,6 +15,8 @@
 namespace OdinData
 {
 
+//! ParamContainerException - custom exception class for ParamContainer implementing "what" for
+//! error string
 class ParamContainerException : public std::exception
 {
 public:
@@ -40,7 +49,7 @@ private:
 
 } // namespace OdinData
 
-// Override rapidsjon assertion mechanism before including appropriate headers
+// Override RapidJSON assertion mechanism before including appropriate headers
 #ifdef RAPIDJSON_ASSERT
 #undef RAPIDJSON_ASSERT
 #endif
@@ -54,72 +63,141 @@ private:
 namespace OdinData
 {
 
+//! ParamContainer - parameter container with JSON encoding/decoding
 class ParamContainer
 {
 
+    //! Parameter setter function type definition
     typedef boost::function<void(rapidjson::Value&)> SetterFunc;
+    //! Parameter setter function map type definition
     typedef std::map<std::string, SetterFunc> SetterFuncMap;
+    //! Parameter getter function type definition
     typedef boost::function<void(rapidjson::Value&)> GetterFunc;
+    //! Parameter getter function map type definition
     typedef std::map<std::string, GetterFunc> GetterFuncMap;
 
     public:
 
+        //! Use the RapidJSON Document type throughout
         typedef rapidjson::Document Document;
 
+        //! Encodes the parameter container to a JSON-formatted string
         std::string encode(void);
+
+        //! Encodes the parameter container into an existing document, using the specified path
+        //! as a prefix for all parameter paths
         void encode(ParamContainer::Document& doc_obj, std::string prefix_path = std::string());
+
+        //! Updates the values of parameters from the specified JSON-formatted string
         void update(std::string json);
+
+        //! Updates the values of the parameters from the specified JSON-formatted character array
         void update(const char* json);
+
+        //! Updates the values of the parameters from the specified JSON document
         void update(ParamContainer::Document& doc_obj);
 
     protected:
 
+        //! Binds a parameter to a path in the container.
+        //!
+        //! This template method binds the specified parameter to the specified path in the
+        //! container, allowing the value of the parameter to be read or updated from an appropriate
+        //! JSON message.
+        //!
+        //! \param param - reference to the parameter to bind
+        //! \param path - JSON pointer-like path to bind the parameter to
+
         template<typename T>
         void bind_param(T& param, const std::string& path)
         {
+            // Bind the parameter into the setter function map
             setter_map_[path] = boost::bind(
-                &ParamContainer::param_set<T>, this, boost::ref(param), path,
-                boost::placeholders::_1
+                &ParamContainer::param_set<T>, this, boost::ref(param), boost::placeholders::_1
             );
 
+            // Bind the parameter into the getter function map
             getter_map_[path] = boost::bind(
-                &ParamContainer::param_get<T>, this, boost::ref(param), path,
-                boost::placeholders::_1
+                &ParamContainer::param_get<T>, this, boost::ref(param), boost::placeholders::_1
             );
 
         }
+
+        //! Binds a vector parameter to a path in the container.
+        //!
+        //! This template method binds the specified vector parameter of a given type to the
+        //! specified path in the parameter container, allowing the value of the parameter to be
+        //! read or updated from an appropriate JSON message.
+        //!
+        //! \param param - reference to the vector parameter to bind
+        //! \param path - JSON pointer-like path to bind the parameter to
 
         template<typename T>
         void bind_vector_param(std::vector<T>& param, const std::string& path)
         {
+            // Bind the vector parameter into the setter function map
             setter_map_[path] = boost::bind(
-                &ParamContainer::vector_param_set<T>, this, boost::ref(param), path,
+                &ParamContainer::vector_param_set<T>, this, boost::ref(param),
                 boost::placeholders::_1
             );
 
+            // Bind the vector parameter into the getter function map
             getter_map_[path] = boost::bind(
-                &ParamContainer::vector_param_get<T>, this, boost::ref(param), path,
+                &ParamContainer::vector_param_get<T>, this, boost::ref(param),
                 boost::placeholders::_1
             );
         }
 
+        //! Sets the value of a parameter in the container.
+        //!
+        //! This template method sets the value of of a parameter in the container to the value
+        //! given the JSON object passed as an argument. This method is bound into the setter
+        //! function map of the container and invoked by the update method. The type-specific
+        //! set_value method is used to update the parameter value from the JSON object.
+        //!
+        //! \param param - reference to the parameter to update
+        //! \param value_obj - reference to a RapidJSON value object containing the value to set
+
         template<typename T>
-        void param_set(T& param, std::string path, rapidjson::Value& value_obj)
+        void param_set(T& param, rapidjson::Value& value_obj)
         {
             param = set_value<T>(value_obj);
         }
 
+        //! Gets the value of a parameter in the container.
+        //!
+        //! This template method gets the value of a parameter in the container, setting that value
+        //! in the JSON object passed as an argument. This method is bound into the getter
+        //! function map of the container and invoked by the encode method. The type-specific
+        //! get_value method is used to udpate the JSON object with the parameter value.
+        //!
+        //! \param param - reference to the parameter to retrieve
+        //! \param value_obj - reference to a RapidJSON value object to be set with the value
+
         template<typename T> const
-        void param_get(T& param, std::string path, rapidjson::Value& value_obj)
+        void param_get(T& param, rapidjson::Value& value_obj)
         {
             get_value<T>(param, value_obj);
         }
 
-        template<typename T>
-        void vector_param_set(std::vector<T>& param, std::string& path, rapidjson::Value& value_obj)
+        //! Sets the value of a vector parameter in the container.
+        //!
+        //! This template method sets the value of of a vector parameter in the container to the
+        //! values given the JSON object passed as an argument. This method is bound into the setter
+        //! function map of the container and invoked by the update method. The type-specific
+        //! set_value method is used to update the parameter values from the JSON object.
+        //!
+        //! \param param - reference to the vector parameter to update
+        //! \param value_obj - reference to a RapidJSON value object containing the value to set
+
+       template<typename T>
+        void vector_param_set(std::vector<T>& param, rapidjson::Value& value_obj)
         {
+            // Clear the existing values in the parameter vector
             param.clear();
 
+            // Iterate through the values of the parameter in the value object and add to the
+            // parameter vector
             for (rapidjson::Value::ValueIterator itr = value_obj.Begin();
                 itr != value_obj.End(); ++itr)
             {
@@ -127,13 +205,26 @@ class ParamContainer
             }
         }
 
+        //! Gets the value of a vector parameter in the container.
+        //!
+        //! This template method gets the value of a vector parameter in the container, setting
+        //! those values in the JSON object passed as an argument. This method is bound into the
+        //! getter function map of the container and invoked by the encode method. The type-specific
+        //! get_value method is used to udpate the JSON object with the parameter values.
+        //!
+        //! \param param - reference to the vector parameter to retrieve
+        //! \param value_obj - reference to a RapidJSON value object to be set with the values
+
         template<typename T>
-        void vector_param_get(std::vector<T>& param, std::string& path, rapidjson::Value& value_obj)
+        void vector_param_get(std::vector<T>& param, rapidjson::Value& value_obj)
         {
+            // Create a new JSON array object to hold the parameter values using RapidJSON swap
+            // semantics
             rapidjson::Document::AllocatorType& allocator = doc_.GetAllocator();
             rapidjson::Value vec_obj(rapidjson::kArrayType);
             value_obj.Swap(vec_obj);
 
+            // Iterate through the values in the parameter vector and add to the value object
             for (typename std::vector<T>::iterator itr = param.begin(); itr != param.end(); ++itr)
             {
                 rapidjson::Value val;
@@ -144,18 +235,54 @@ class ParamContainer
 
     private:
 
+        //! Sets the value of a parameter.
+        //!
+        //! This private template method is used by the param_set method to set the value of a
+        //! parameter from the specified JSON object. Explicit specialisations of this method
+        //! are provided, mapping each of the RapidJSON types onto the appropriate parameter types,
+        //! which is returned as a value.
+        //!
+        //! \param value_obj - reference to a RapidJSON value object containing the value
+        //! \return the value of the appropriate type
+
         template<typename T> T set_value(rapidjson::Value& value_obj) const;
+
+        //! Gets the value of a parameter.
+        //!
+        //! This private template method is used by the param_get method to get the value of a
+        //! parameter and place it in the specified JSON object. Explicit specialisations of this
+        //! method are provided, mapping each of the parameter types on the appropriate RapidJSON
+        //! types.
+        //!
+        //! \param param - reference to the parameter to get the value of
+        //! \param value_obj - RapidJSON value object to update with the value of the parameter
+
         template<typename T> void get_value(T& param, rapidjson::Value& value_obj) const;
+
+        //! Constructs a valid JSON pointer path.
+        //!
+        //! This private utility method is used to construct a valid JSON pointer path, ensuring
+        //! that the leading / prefix is present.
+        //!
+        //! \param path - reference to path string
+        //! \return valid pointer path string
 
         inline const std::string pointer_path(const std::string& path)
         {
-            std::string pointer_path = "/" + path;
+            // Set the pointer to the specified path
+            std::string pointer_path(path);
+
+            // If the pointer is not prefixed with the required slash, insert it
+            if (*pointer_path.begin() != '/')
+            {
+                pointer_path.insert(0, "/");
+            }
             return pointer_path;
         }
 
-        SetterFuncMap setter_map_;
-        GetterFuncMap getter_map_;
-        ParamContainer::Document doc_;
+        SetterFuncMap setter_map_;      //!< Paramter setter function map
+        GetterFuncMap getter_map_;      //!< Parameter getter function map
+        ParamContainer::Document doc_;  //!< JSON document object used for encoding
 };
 
 } // namespace OdinData

--- a/data/frameReceiver/include/PcoCameraConfiguration.h
+++ b/data/frameReceiver/include/PcoCameraConfiguration.h
@@ -46,7 +46,39 @@ namespace FrameReceiver
                 exposure_time_(0.0),
                 frame_rate_(0.0)
             {
-                // Bind parameters in the container
+                // Bind the parameters in the container
+                bind_params();
+            }
+
+            //! Copy constructor
+            //!
+            //! This constructor creates a copy of an existing configuration object. All parameters
+            //! are first bound and then the underlying parameter container is updated from the
+            //! existing object. This mechansim is necessary (rather than relying on a default copy
+            //! constructor) since it is not possible for a parameter container to automatically
+            //! rebind parameters defined in a derived class.
+            //!
+            //! \param config - existing config object to copy
+
+            PcoCameraConfiguration(const PcoCameraConfiguration& config) :
+                ParamContainer(config)
+            {
+                // Bind the parameters in the container
+                bind_params();
+
+                // Update the container from the existing config object
+                update(config);
+            }
+
+        private:
+
+            //! Bind parameters in the container
+            //!
+            //! This method binds all the parameters in the container to named paths. This method
+            //! is separated out so that it can be used in both default and copy constructors.
+
+            virtual void bind_params(void)
+            {
                 bind_param<unsigned int>(camera_num_, "camera_num");
                 bind_param<double>(image_timeout_, "image_timeout");
                 bind_param<unsigned int>(num_frames_, "num_frames");
@@ -54,8 +86,6 @@ namespace FrameReceiver
                 bind_param<double>(exposure_time_, "exposure_time");
                 bind_param<double>(frame_rate_, "frame_rate");
             }
-
-        private:
 
             unsigned int camera_num_;     //!< Camera number as enumerated by driver
             double image_timeout_;        //!< Image acquisition timeout in seconds

--- a/data/frameReceiver/include/PcoCameraConfiguration.h
+++ b/data/frameReceiver/include/PcoCameraConfiguration.h
@@ -1,32 +1,58 @@
+/*!
+ * PcoCameraConfiguration.h - configuration parameter container for the PCO camera
+ *
+ * This class implements a configuration parameter container for the PCO camera, containing
+ * the parameters necessary for operating the camera.
+ *
+ * Created on: Sep 24, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
 #ifndef PCOCAMERACONFIGURATION_H_
 #define PCOCAMERACONFIGURATION_H_
+
 #include "ParamContainer.h"
 
 namespace FrameReceiver
 {
+    //! Default values for configuration parameters. NB some parameters are synchronised from the
+    //! existing state of the camera at startup.
     namespace Defaults
     {
-        const unsigned int default_num_frames = 0;
+        const unsigned int default_num_frames = 0; //!< Default number of frames: 0 = no limit
     }
+
+    //! PcoCameraConfiguration - PCO camera configuration parameter container
     class PcoCameraConfiguration : public OdinData::ParamContainer
     {
 
         public:
+
+            //! Default constructor
+            //!
+            //! This constructor initialises all parameters to default values and binds the
+            //! parameters in the container, allowing them to accessed via the path-like set/get
+            //! mechanism implemented in ParamContainer.
+
             PcoCameraConfiguration() :
                 ParamContainer(),
                 num_frames_(Defaults::default_num_frames),
                 exposure_time_(0.0),
                 frame_rate_(0.0)
             {
+                // Bind parameters in the container
                 bind_param<unsigned int>(num_frames_, "num_frames");
                 bind_param<double>(exposure_time_, "exposure_time");
                 bind_param<double>(frame_rate_, "frame_rate");
             }
 
         private:
-            unsigned int num_frames_;
-            double exposure_time_;
-            double frame_rate_;
+
+            unsigned int num_frames_; //!< Number of frames to acquire, 0 = no limit
+            double exposure_time_;    //!< Exposure time in seconds
+            double frame_rate_;       //!< Frame rate in Hertz
+
+            //! Allow the PcoCameraLinkController class direct access to config parameters
             friend class PcoCameraLinkController;
 
     };

--- a/data/frameReceiver/include/PcoCameraConfiguration.h
+++ b/data/frameReceiver/include/PcoCameraConfiguration.h
@@ -15,19 +15,18 @@ namespace FrameReceiver
             PcoCameraConfiguration() :
                 ParamContainer(),
                 num_frames_(Defaults::default_num_frames),
-                exposure_time_(0),
-                delay_time_(0)
+                exposure_time_(0.0),
+                frame_rate_(0.0)
             {
                 bind_param<unsigned int>(num_frames_, "num_frames");
-                bind_param<unsigned int>(exposure_time_, "exposure_time_ms");
-                bind_param<unsigned int>(delay_time_, "delay_time_ms");
+                bind_param<double>(exposure_time_, "exposure_time");
+                bind_param<double>(frame_rate_, "frame_rate");
             }
 
         private:
             unsigned int num_frames_;
-            unsigned int exposure_time_;
-            unsigned int delay_time_;
-
+            double exposure_time_;
+            double frame_rate_;
             friend class PcoCameraLinkController;
 
     };

--- a/data/frameReceiver/include/PcoCameraConfiguration.h
+++ b/data/frameReceiver/include/PcoCameraConfiguration.h
@@ -22,6 +22,7 @@ namespace FrameReceiver
         const unsigned int default_camera_num = 0; //!< Default camera number
         const double default_image_timeout = 10.0; //!< Default image acquisition timeout
         const unsigned int default_num_frames = 0; //!< Default number of frames: 0 = no limit
+        const unsigned int default_timestamp_mode = 2; //!< Default timestamp mode 2 = binary/ASCII
     }
 
     //! PcoCameraConfiguration - PCO camera configuration parameter container
@@ -41,6 +42,7 @@ namespace FrameReceiver
                 camera_num_(Defaults::default_camera_num),
                 image_timeout_(Defaults::default_image_timeout),
                 num_frames_(Defaults::default_num_frames),
+                timestamp_mode_(Defaults::default_timestamp_mode),
                 exposure_time_(0.0),
                 frame_rate_(0.0)
             {
@@ -48,17 +50,19 @@ namespace FrameReceiver
                 bind_param<unsigned int>(camera_num_, "camera_num");
                 bind_param<double>(image_timeout_, "image_timeout");
                 bind_param<unsigned int>(num_frames_, "num_frames");
+                bind_param<unsigned int>(timestamp_mode_, "timestamp_mode");
                 bind_param<double>(exposure_time_, "exposure_time");
                 bind_param<double>(frame_rate_, "frame_rate");
             }
 
         private:
 
-            unsigned int camera_num_; //!< Camera number as enumerated by driver
-            double image_timeout_;    //!< Image acquisition timeout in seconds
-            unsigned int num_frames_; //!< Number of frames to acquire, 0 = no limit
-            double exposure_time_;    //!< Exposure time in seconds
-            double frame_rate_;       //!< Frame rate in Hertz
+            unsigned int camera_num_;     //!< Camera number as enumerated by driver
+            double image_timeout_;        //!< Image acquisition timeout in seconds
+            unsigned int num_frames_;     //!< Number of frames to acquire, 0 = no limit
+            unsigned int timestamp_mode_; //!< Camera timestamp mode
+            double exposure_time_;        //!< Exposure time in seconds
+            double frame_rate_;           //!< Frame rate in Hertz
 
             //! Allow the PcoCameraLinkController class direct access to config parameters
             friend class PcoCameraLinkController;

--- a/data/frameReceiver/include/PcoCameraConfiguration.h
+++ b/data/frameReceiver/include/PcoCameraConfiguration.h
@@ -19,6 +19,8 @@ namespace FrameReceiver
     //! existing state of the camera at startup.
     namespace Defaults
     {
+        const unsigned int default_camera_num = 0; //!< Default camera number
+        const double default_image_timeout = 10.0; //!< Default image acquisition timeout
         const unsigned int default_num_frames = 0; //!< Default number of frames: 0 = no limit
     }
 
@@ -36,11 +38,15 @@ namespace FrameReceiver
 
             PcoCameraConfiguration() :
                 ParamContainer(),
+                camera_num_(Defaults::default_camera_num),
+                image_timeout_(Defaults::default_image_timeout),
                 num_frames_(Defaults::default_num_frames),
                 exposure_time_(0.0),
                 frame_rate_(0.0)
             {
                 // Bind parameters in the container
+                bind_param<unsigned int>(camera_num_, "camera_num");
+                bind_param<double>(image_timeout_, "image_timeout");
                 bind_param<unsigned int>(num_frames_, "num_frames");
                 bind_param<double>(exposure_time_, "exposure_time");
                 bind_param<double>(frame_rate_, "frame_rate");
@@ -48,6 +54,8 @@ namespace FrameReceiver
 
         private:
 
+            unsigned int camera_num_; //!< Camera number as enumerated by driver
+            double image_timeout_;    //!< Image acquisition timeout in seconds
             unsigned int num_frames_; //!< Number of frames to acquire, 0 = no limit
             double exposure_time_;    //!< Exposure time in seconds
             double frame_rate_;       //!< Frame rate in Hertz

--- a/data/frameReceiver/include/PcoCameraDelayExposureConfig.h
+++ b/data/frameReceiver/include/PcoCameraDelayExposureConfig.h
@@ -1,0 +1,82 @@
+/*!
+ * PcoCameraDelayExposureConfig.h - PCO camera delay and exposure configuration container
+ *
+ * Created on: Oct 20, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
+#ifndef PCOCAMERADELAYEXPOSURECONFIG_H_
+#define PCOCAMERADELAYEXPOSURECONFIG_H_
+
+#include <map>
+
+#include "Cpco_com.h"
+
+namespace FrameReceiver
+{
+    //! PcoCameraDelayExposure - PCO camera delay and exposure configuration settings container
+    class PcoCameraDelayExposure
+    {
+        public:
+
+            //! Camera delay and exposure timebase values
+            enum PcoCameraTimebase
+            {
+                TimebaseUnknown = -1, //!< Unknown timebase
+                TimebaseNs = 0,       //!< Timebase in nanoseconds
+                TimebaseUs = 1,       //!< Timebase in microseconds
+                TimebaseMs = 2,       //!< Timebase in milliseconds
+            };
+
+            //! Internal mappings of timebases to time values and unit string names
+            typedef std::map<PcoCameraTimebase, double> TimebaseValueMap;
+            typedef std::map<PcoCameraTimebase, std::string> TimebaseNameMap;
+
+            //! Default constructor
+            PcoCameraDelayExposure();
+
+            //! Constructor taking exposure time and frame rate as arguments
+            PcoCameraDelayExposure(double exposure_time, double frame_rate);
+
+            //! Returns the current exposure timebase unit as a string
+            const std::string exposure_timebase_unit(void);
+
+            //! Returns the current delay timebase unit as a string
+            const std::string delay_timebase_unit(void);
+
+            //! Returns the current exposure time in seconds as a double
+            double exposure_time(void);
+
+            //! Returns the current frame rate in Hertz as a double
+            double frame_rate(void);
+
+            //! Equality and inequality operators
+            bool operator==(const PcoCameraDelayExposure& other);
+            bool operator!=(const PcoCameraDelayExposure& other) { return !(*this == other); }
+
+        private:
+
+            //! Returns the timebase value in seconds for the specified timebase
+            const double timebase_value(unsigned int timebase);
+
+            //! Returns the timebase name as a string for the specified timebase
+            const std::string timebase_name(unsigned int timebase);
+
+            //! Selects the appropriate timebase value for a specified desired time value
+            PcoCameraTimebase select_timebase(double time_value);
+
+            DWORD exposure_time_;     //!< Exposure config setting in current timebase
+            DWORD delay_time_;        //!< Delay config setting in current timebase
+            WORD exposure_timebase_;  //!< Current exposure timebase config setting
+            WORD delay_timebase_;     //!< Current delay timebase config setting
+
+            //! Static declaration of the internal timebase value and name maps
+            static TimebaseValueMap timebase_value_map_;
+            static TimebaseNameMap timebase_name_map_;
+
+            //! Allow the PcoCameraLinkController class direct access to config fields
+            friend class PcoCameraLinkController;
+    };
+}
+
+#endif //  PCOCAMERADELAYEXPOSURECONFIG_H_

--- a/data/frameReceiver/include/PcoCameraError.h
+++ b/data/frameReceiver/include/PcoCameraError.h
@@ -1,0 +1,24 @@
+/*
+ * PcoCameraError.h - PCO camera error message implementation
+ *
+ * Created on: 03 Nov 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
+#ifndef PCOCAMERAERROR_H_
+#define PCOCAMERAERROR_H_
+#include "defs.h"
+
+// Wrap the inclusion of the PCO error text header file in extern C so that C-linkage is used
+// for the PCO_GetErrorText function
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "PCO_errt.h"
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif // PCOCAMERAERROR_H_

--- a/data/frameReceiver/include/PcoCameraLinkController.h
+++ b/data/frameReceiver/include/PcoCameraLinkController.h
@@ -19,6 +19,7 @@ using namespace log4cxx::helpers;
 
 #include "PcoCameraStateMachine.h"
 #include "PcoCameraConfiguration.h"
+#include "PcoCameraDelayExposureConfig.h"
 #include "PcoCameraStatus.h"
 
 #include "Cpco_com.h"
@@ -47,7 +48,7 @@ namespace FrameReceiver
     void get_configuration(ParamContainer::Document& params);
     void get_status(ParamContainer::Document& params, const std::string param_prefix);
 
-    bool acquire_image(void* image_buffer);
+    bool acquire_image(void* image_buffer, int timeout);
 
     void disconnect(void);
     void connect(void);
@@ -70,6 +71,7 @@ namespace FrameReceiver
     PcoCameraState camera_state_;
     PcoCameraConfiguration camera_config_;
     PcoCameraStatus camera_status_;
+    PcoCameraDelayExposure camera_delay_exp_;
     boost::shared_ptr<boost::thread> controller_thread_;
     std::string notify_endpoint_;
 

--- a/data/frameReceiver/include/PcoCameraLinkController.h
+++ b/data/frameReceiver/include/PcoCameraLinkController.h
@@ -58,10 +58,10 @@ namespace FrameReceiver
     std::size_t get_image_size(void);
 
     //! Executes a camera control command
-    void execute_command(std::string& command);
+    bool execute_command(std::string& command);
 
     //! Updates the configuration of the camera from a parameter document
-    void update_configuration(ParamContainer::Document& params);
+    bool update_configuration(ParamContainer::Document& params);
 
     //! Gets the current configuration of the camera encoded into a parameter document
     void get_configuration(ParamContainer::Document& params, const std::string param_prefix);

--- a/data/frameReceiver/include/PcoCameraLinkController.h
+++ b/data/frameReceiver/include/PcoCameraLinkController.h
@@ -2,7 +2,7 @@
  * PcoCameraLinkController.h - controller class for the PCO camera integration into odin-data
  *
  * Created on: 20 July 2021
- *     Author: Tim Nicholls, STFC Detector Systems Group
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
  */
 
 #ifndef INCLUDE_PCOCAMERALINKCONTROLLER_H_
@@ -100,6 +100,9 @@ namespace FrameReceiver
 
     //! Calculates the image number from the timestamp in the first pixel data
     int image_nr_from_timestamp(void *image_buffer, int shift);
+
+    //! Returns a readable error string for a camera error code
+    std::string pco_error_text(DWORD pco_error);
 
     LoggerPtr logger_;                                   //!< Pointer to the message logger
     PcoCameraLinkFrameDecoder* decoder_;                 //!< Pointer to the frame decoder instance

--- a/data/frameReceiver/include/PcoCameraLinkController.h
+++ b/data/frameReceiver/include/PcoCameraLinkController.h
@@ -1,5 +1,5 @@
 /*
- * PcoCameraLinkController.h
+ * PcoCameraLinkController.h - controller class for the PCO camera integration into odin-data
  *
  * Created on: 20 July 2021
  *     Author: Tim Nicholls, STFC Detector Systems Group
@@ -30,65 +30,96 @@ using namespace OdinData;
 namespace FrameReceiver
 {
 
-  class PcoCameraLinkFrameDecoder; // forward declaration
+  class PcoCameraLinkFrameDecoder; // Forward declaration of the decoder class
 
   class PcoCameraLinkController
   {
   public:
+
+    //! Constructor for the controller taking a pointer to the decoder as a argument
     PcoCameraLinkController(PcoCameraLinkFrameDecoder* decoder);
+
+    //! Destructor for the controller class
     ~PcoCameraLinkController();
 
+    //! Returns the camera image width in number of pixels
     uint32_t get_image_width(void);
+
+    //! Returns the camera image height in number of pixels
     uint32_t get_image_height(void);
+
+    //! Returns the camera image data type required for the frame header parameters
     int get_image_data_type(void);
+
+    //! Returns the camera image size in bytes
     std::size_t get_image_size(void);
 
+    //! Executes a camera control command
     void execute_command(std::string& command);
+
+    //! Updates the configuration of the camera from a parameter document
     void update_configuration(ParamContainer::Document& params);
-    void get_configuration(ParamContainer::Document& params);
+
+    //! Gets the current configuration of the camera encoded into a parameter document
+    void get_configuration(ParamContainer::Document& params, const std::string param_prefix);
+
+    //! Gets the current status of the camera encoded into a parameter document
     void get_status(ParamContainer::Document& params, const std::string param_prefix);
 
-    bool acquire_image(void* image_buffer, int timeout);
-
+    //! Disconnects from the camera
     void disconnect(void);
+
+    //! Connects to the camera
     void connect(void);
+
+    //! Arms the camera, preparing for recording
     void arm(void);
+
+    //! Disarms the camera
     void disarm(void);
+
+    //! Starts the camera recording, allowing images to be acquired
     void start_recording(void);
+
+    //! Stops the camera recording
     void stop_recording(void);
 
+    //! Runs the camera control loop service
     void run_camera_service(void);
 
+    //! Returns the name of the current camera state
     std::string camera_state_name(void);
-    bool camera_running(void) { return camera_running_; }
+
+    //! Returns true if the camera is currently recording
+    bool camera_recording(void) { return camera_recording_; }
 
   private:
 
-    int image_nr_from_timestamp(void *buf,int shift);
+    //! Acquires an image from camera into an image buffer
+    bool acquire_image(void* image_buffer, int timeout);
 
-    LoggerPtr logger_;
-    PcoCameraLinkFrameDecoder* decoder_;
-    PcoCameraState camera_state_;
-    PcoCameraConfiguration camera_config_;
-    PcoCameraStatus camera_status_;
-    PcoCameraDelayExposure camera_delay_exp_;
-    boost::shared_ptr<boost::thread> controller_thread_;
-    std::string notify_endpoint_;
+    //! Calculates the image number from the timestamp in the first pixel data
+    int image_nr_from_timestamp(void *image_buffer, int shift);
 
-    boost::scoped_ptr<CPco_com> camera_;
-    boost::scoped_ptr<CPco_grab_clhs> grabber_;
+    LoggerPtr logger_;                                   //!< Pointer to the message logger
+    PcoCameraLinkFrameDecoder* decoder_;                 //!< Pointer to the frame decoder instance
+    PcoCameraState camera_state_;                        //!< Camera state machine instance
+    PcoCameraConfiguration camera_config_;               //!< Camera config parameter container
+    PcoCameraStatus camera_status_;                      //!< Camera status parameter container
+    PcoCameraDelayExposure camera_delay_exp_;            //!< Camera delay/exposure instance
+    boost::shared_ptr<boost::thread> controller_thread_; //!< Pointer to controller service thread
 
-    bool camera_opened_;
-    bool grabber_opened_;
-    volatile bool camera_running_;
+    boost::scoped_ptr<CPco_com> camera_;        //!< Scoped pointer to camera instance
+    boost::scoped_ptr<CPco_grab_clhs> grabber_; //!< Scoped pointer to frame grabber instance
 
-    int camera_num_;
-    int grabber_timeout_ms_;
+    bool camera_opened_;             //!< Indicates if camera connection is opened
+    bool grabber_opened_;            //!< Indicates if frame grabber connection is opened
+    volatile bool camera_recording_; //!< Indicates if camera is recording
 
-    uint32_t image_width_;
-    uint32_t image_height_;
-    uint32_t image_pixel_size_;
-    std::size_t image_data_type_;
+    uint32_t image_width_;        //!< Image width in pixels
+    uint32_t image_height_;       //!< Image height in pixels
+    uint32_t image_pixel_size_;   //!< Image pixel size in bytes
+    std::size_t image_data_type_; //!< Image data type for frame header
 
   };
 }

--- a/data/frameReceiver/include/PcoCameraLinkController.h
+++ b/data/frameReceiver/include/PcoCameraLinkController.h
@@ -32,6 +32,8 @@ namespace FrameReceiver
 
   class PcoCameraLinkFrameDecoder; // Forward declaration of the decoder class
 
+  const DWORD default_pco_error = -1;
+
   class PcoCameraLinkController
   {
   public:
@@ -67,22 +69,22 @@ namespace FrameReceiver
     void get_status(ParamContainer::Document& params, const std::string param_prefix);
 
     //! Disconnects from the camera
-    void disconnect(void);
+    bool disconnect(bool reset_error_status = false);
 
     //! Connects to the camera
-    void connect(void);
+    bool connect(void);
 
     //! Arms the camera, preparing for recording
-    void arm(void);
+    bool arm(void);
 
     //! Disarms the camera
-    void disarm(void);
+    bool disarm(void);
 
     //! Starts the camera recording, allowing images to be acquired
-    void start_recording(void);
+    bool start_recording(void);
 
     //! Stops the camera recording
-    void stop_recording(void);
+    bool stop_recording(void);
 
     //! Runs the camera control loop service
     void run_camera_service(void);
@@ -100,6 +102,9 @@ namespace FrameReceiver
 
     //! Calculates the image number from the timestamp in the first pixel data
     int image_nr_from_timestamp(void *image_buffer, int shift);
+
+    //! Checks camera error codes, setting camera error status and emitting error messages
+    bool check_pco_error(const std::string message, DWORD pco_error = default_pco_error);
 
     //! Returns a readable error string for a camera error code
     std::string pco_error_text(DWORD pco_error);

--- a/data/frameReceiver/include/PcoCameraLinkController.h
+++ b/data/frameReceiver/include/PcoCameraLinkController.h
@@ -33,7 +33,8 @@ namespace FrameReceiver
   class PcoCameraLinkFrameDecoder; // Forward declaration of the decoder class
 
   const DWORD default_pco_error = -1;
-
+  const WORD recording_state_stopped = 0;
+  const WORD recording_state_running = 1;
   class PcoCameraLinkController
   {
   public:

--- a/data/frameReceiver/include/PcoCameraLinkFrameDecoder.h
+++ b/data/frameReceiver/include/PcoCameraLinkFrameDecoder.h
@@ -1,5 +1,5 @@
  /*
- * PcoCameraLinkFrameDecoder.h
+ * PcoCameraLinkFrameDecoder.h - frame decoder implementation for the PCO camera system
  *
  *  Created on: 20 July 2021
  *      Author: Tim Nicholls, STFC Detector Systems Software Group
@@ -20,36 +20,66 @@ namespace FrameReceiver
 {
 
   const std::string CAMERA_CONFIG_PATH = "camera";
+  const std::string CAMERA_COMMAND_PATH = "command";
 
   class PcoCameraLinkFrameDecoder : public FrameDecoderCameraLink
   {
   public:
+
+    //! Constructor for the PcoCameraLinkFrameDecoder class
     PcoCameraLinkFrameDecoder();
+
+    //! Destructor for the PcoCameraLinkFrameDecoder class
     ~PcoCameraLinkFrameDecoder();
 
+    //! Returns the decoder version number major value
     int get_version_major();
+
+    //! Returns the decoder version number minor value
     int get_version_minor();
+
+    //! Returns the decoder version number patch value
     int get_version_patch();
+
+    //! Returns the decoder version short string
     std::string get_version_short();
+
+    //! Returns the decoder version long string
     std::string get_version_long();
 
+    //! Initialises the decoder from a configuration message provided by the frame receiver
     void init(LoggerPtr& logger, OdinData::IpcMessage& config_msg);
 
+    //! Returns the frame buffer size required for image acquisition
     const size_t get_frame_buffer_size(void) const;
+
+    //! Returns the frame header size defined for this decoder
     const size_t get_frame_header_size(void) const;
 
+    //! Monitors the state of allocated buffers in the decoder
     void monitor_buffers(void);
 
+    //! Handles camera control channel messages
     void handle_ctrl_channel(void);
-    void configure(OdinData::IpcMessage& config_msg, OdinData::IpcMessage& config_reply);
-    void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply);
-    void get_status(const std::string param_prefix, OdinData::IpcMessage& status_msg);
 
+    //! Configures the decoder and camera based on the content of a configuration message
+    void configure(OdinData::IpcMessage& config_msg, OdinData::IpcMessage& config_reply);
+
+    //! Returns the current camera configuration parameters in an IPC message
+    void request_configuration(const std::string param_prefix, OdinData::IpcMessage& config_reply);
+
+    //! Returns the current status of the camera in an IPC message
+    void get_status(const std::string param_prefix, OdinData::IpcMessage& status_reply);
+
+    //! Indicates if the camera control service thread is currently running
     const bool run_camera_service_thread(void) const { return run_thread_; }
 
   private:
 
+    //! Runs the camera control service
     void run_camera_service(void);
+
+    //! Scoped pointer to the current PCO camera controller instance
     boost::scoped_ptr<PcoCameraLinkController> controller_;
 
   };

--- a/data/frameReceiver/include/PcoCameraLinkFrameDecoder.h
+++ b/data/frameReceiver/include/PcoCameraLinkFrameDecoder.h
@@ -9,6 +9,7 @@
 #define INCLUDE_PCOCAMERALINKFRAMEDECODER_H_
 
 #include <iostream>
+#include <string>
 #include <boost/scoped_ptr.hpp>
 #include <boost/thread.hpp>
 
@@ -17,6 +18,9 @@
 
 namespace FrameReceiver
 {
+
+  const std::string CAMERA_CONFIG_PATH = "camera";
+
   class PcoCameraLinkFrameDecoder : public FrameDecoderCameraLink
   {
   public:

--- a/data/frameReceiver/include/PcoCameraStateMachine.h
+++ b/data/frameReceiver/include/PcoCameraStateMachine.h
@@ -81,6 +81,7 @@ namespace FrameReceiver
     struct EventDisconnect : sc::event<EventDisconnect> {};   //!< Camera disconnect event
     struct EventArm : sc::event<EventArm> {};                 //!< Camera arm event
     struct EventDisarm : sc::event<EventDisarm> {};           //!< Camera disarm event
+    struct EventRearm : sc::event<EventRearm> {};             //!< Camera rearm event
     struct EventRecordStart : sc::event<EventRecordStart> {}; //!< Camera recording start event
     struct EventRecordStop : sc::event<EventRecordStop> {};   //!< Camera recording stop event
     struct EventReset : sc::event<EventReset> {};             //!< Camera reset event
@@ -106,6 +107,7 @@ namespace FrameReceiver
             CommandDisconnect,     //!< Disconnect command
             CommandArm,            //!< Arm command
             CommandDisarm,         //!< Disarm command
+            CommandRearm,          //!< Rearm command
             CommandStartRecording, //!< Start recording command
             CommandStopRecording,  //!< Stop recording command
             CommandReset           //!< Reset command
@@ -257,6 +259,7 @@ namespace FrameReceiver
            //! Defines reactions to legal events
            typedef mpl::list<
                 sc::custom_reaction<EventDisarm>,
+                sc::custom_reaction<EventRearm>,
                 sc::custom_reaction<EventRecordStart>
             > reactions;
 
@@ -265,6 +268,8 @@ namespace FrameReceiver
 
             //! Reacts to disarm transition events
             sc::result react(const EventDisarm&);
+            //! Reacts to rearm transition events
+            sc::result react(const EventRearm&);
             //! Reacts to record start transition events
             sc::result react(const EventRecordStart&);
 

--- a/data/frameReceiver/include/PcoCameraStateMachine.h
+++ b/data/frameReceiver/include/PcoCameraStateMachine.h
@@ -82,13 +82,15 @@ namespace FrameReceiver
     struct EventArm : sc::event<EventArm> {};                 //!< Camera arm event
     struct EventDisarm : sc::event<EventDisarm> {};           //!< Camera disarm event
     struct EventRecordStart : sc::event<EventRecordStart> {}; //!< Camera recording start event
-    struct EventRecordStop : sc::event<EventRecordStop> {} ;  //!< Camera recording stop event
+    struct EventRecordStop : sc::event<EventRecordStop> {};   //!< Camera recording stop event
+    struct EventReset : sc::event<EventReset> {};             //!< Camera reset event
 
     //! Forward declaration of states
     struct Disconnected;
     struct Connected;
     struct Armed;
     struct Recording;
+    struct Error;
 
     // Forward declaration of the controller class
     class PcoCameraLinkController;
@@ -99,13 +101,14 @@ namespace FrameReceiver
         //! State transition command type enumeration
         enum CommandType
         {
-            CommandUnknown = -1,   //!< Unknown event
-            CommandConnect,        //!< Connect event
-            CommandDisconnect,     //!< Disconnect event
-            CommandArm,            //!< Arm event
-            CommandDisarm,         //!< Disarm event
-            CommandStartRecording, //!< Start recording event
-            CommandStopRecording   //!< Stop recording event
+            CommandUnknown = -1,   //!< Unknown command
+            CommandConnect,        //!< Connect command
+            CommandDisconnect,     //!< Disconnect command
+            CommandArm,            //!< Arm command
+            CommandDisarm,         //!< Disarm command
+            CommandStartRecording, //!< Start recording command
+            CommandStopRecording,  //!< Stop recording command
+            CommandReset           //!< Reset command
         };
 
         //! State type enumeration
@@ -115,7 +118,8 @@ namespace FrameReceiver
             StateDisconnected,  //!< Disconnected state
             StateConnected,     //!< Connected state
             StateArmed,         //!< Armed state
-            StateRecording      //!< Recording state
+            StateRecording,     //!< Recording state
+            StateError          //!< Error state
         };
 
         //! Command type map type definition
@@ -296,6 +300,34 @@ namespace FrameReceiver
             PcoCameraState::StateType state_type(void) const
             {
                 return PcoCameraState::StateType::StateRecording;
+            }
+    };
+
+    //! Error - error state class
+    //!
+    //! The error state is occupried when the controller signals that a state transition command
+    //! or other camera operation has failed.
+    //!
+    //! The following state transition events are supported:
+    //!
+    //!    error -> disconnected
+
+    struct Error : IStateInfo, sc::state<Error, PcoCameraState>
+    {
+        public:
+            //! Defines reactions to legal events
+            typedef sc::custom_reaction<EventReset> reactions;
+
+            //! Constructor - initialises state machine context
+            Error(my_context ctx) : my_base(ctx) {};
+
+            //! Reacts to reset transition events
+            sc::result react(const EventReset&);
+
+            //! Returns the current state type
+            PcoCameraState::StateType state_type(void) const
+            {
+                return PcoCameraState::StateType::StateError;
             }
     };
 }

--- a/data/frameReceiver/include/PcoCameraStateMachine.h
+++ b/data/frameReceiver/include/PcoCameraStateMachine.h
@@ -1,3 +1,10 @@
+/*
+ * PcoCameraStateMachine.h - finite state machine implementation for the PCO camera controller
+ *
+ * Created on: 22 Sept 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Group
+ */
+
 #ifndef INCLUDE_PCOCAMERASTATEMACHINE_H_
 #define INCLUDE_PCOCAMERASTATEMACHINE_H_
 
@@ -19,6 +26,8 @@ namespace mpl = boost::mpl;
 namespace FrameReceiver
 {
 
+    //! PcoCameraStateException - simple exception class for the state machine, implementing
+    //! an information message accessible via the what() method
     class PcoCameraStateException : public std::exception
     {
     public:
@@ -49,6 +58,8 @@ namespace FrameReceiver
 
     }; // PcoCameraStateException
 
+    //! PcoCameraStateUnknownCommand - PCO camera state machine exception thrown when an
+    //! unrecognised state transition command name is requested
     class PcoCameraStateUnknownCommand : public PcoCameraStateException
     {
     public:
@@ -56,6 +67,8 @@ namespace FrameReceiver
         PcoCameraStateUnknownCommand(const std::string& what) : PcoCameraStateException(what) {};
     };
 
+    //! PcoCameraStateIllegalTransition - PCO camera state machine exception thrown when a state
+    //! transition is requested from a state where it is not valid
     class PcoCameraStateIllegalTransition : public PcoCameraStateException
     {
     public:
@@ -63,103 +76,159 @@ namespace FrameReceiver
         PcoCameraStateIllegalTransition(const std::string& what) : PcoCameraStateException(what) {};
     };
 
-    // Definition of state machine events
-    struct EventConnect : sc::event<EventConnect> {};
-    struct EventDisconnect : sc::event<EventDisconnect> {};
-    struct EventArm : sc::event<EventArm> {};
-    struct EventDisarm : sc::event<EventDisarm> {};
-    struct EventRecordStart : sc::event<EventRecordStart> {} ;
-    struct EventRecordStop : sc::event<EventRecordStop> {} ;
+    //! Definition of state machine events
+    struct EventConnect : sc::event<EventConnect> {};         //!< Camera connect event
+    struct EventDisconnect : sc::event<EventDisconnect> {};   //!< Camera disconnect event
+    struct EventArm : sc::event<EventArm> {};                 //!< Camera arm event
+    struct EventDisarm : sc::event<EventDisarm> {};           //!< Camera disarm event
+    struct EventRecordStart : sc::event<EventRecordStart> {}; //!< Camera recording start event
+    struct EventRecordStop : sc::event<EventRecordStop> {} ;  //!< Camera recording stop event
 
-    // Forward declaration of states
+    //! Forward declaration of states
     struct Disconnected;
     struct Connected;
     struct Armed;
     struct Recording;
 
+    // Forward declaration of the controller class
     class PcoCameraLinkController;
 
+    //! PcoCameraState - state machine for the PCO camera controller
     struct PcoCameraState : sc::state_machine<PcoCameraState, Disconnected>
     {
-        PcoCameraState(PcoCameraLinkController* controller);
-        void unconsumed_event(const sc::event_base& e);
-
+        //! State transition command type enumeration
         enum CommandType
         {
-            CommandUnknown = -1,
-            CommandConnect,
-            CommandDisconnect,
-            CommandArm,
-            CommandDisarm,
-            CommandStartRecording,
-            CommandStopRecording
-        };
-        enum StateType
-        {
-            StateUnknown = -1,
-            StateDisconnected,
-            StateConnected,
-            StateArmed,
-            StateRecording
+            CommandUnknown = -1,   //!< Unknown event
+            CommandConnect,        //!< Connect event
+            CommandDisconnect,     //!< Disconnect event
+            CommandArm,            //!< Arm event
+            CommandDisarm,         //!< Disarm event
+            CommandStartRecording, //!< Start recording event
+            CommandStopRecording   //!< Stop recording event
         };
 
+        //! State type enumeration
+        enum StateType
+        {
+            StateUnknown = -1,  //!< Unknown state
+            StateDisconnected,  //!< Disconnected state
+            StateConnected,     //!< Connected state
+            StateArmed,         //!< Armed state
+            StateRecording      //!< Recording state
+        };
+
+        //! Command type map type definition
+        typedef boost::bimap<std::string, CommandType> CommandTypeMap;
+        //! Command type map entry type definition
+        typedef CommandTypeMap::value_type CommandTypeMapEntry;
+        //! State type map type definition
+        typedef boost::bimap<std::string, StateType> StateTypeMap;
+        //! State type map entry type definition
+        typedef StateTypeMap::value_type StateTypeMapEntry;
+
+        //! Constructor for the PcoCameraState class
+        PcoCameraState(PcoCameraLinkController* controller);
+
+        //! Executes a state transition command
         void execute_command(const char* command);
         void execute_command(std::string& command);
         void execute_command(CommandType command);
 
+        //! Handles unconsumed, i.e. invalid, state transition events
+        void unconsumed_event(const sc::event_base& event);
+
+        //! Maps a command name string to a command type value
         CommandType map_command_to_type(std::string& command);
+
+        //! Maps a state type to a state name
         std::string map_state_to_name(StateType state_type);
 
+        //! Returns the current state name
         std::string current_state_name(void);
+
+        //! Returns the current state type
         StateType current_state(void);
 
-        typedef boost::bimap<std::string, CommandType> CommandTypeMap;
-        typedef CommandTypeMap::value_type CommandTypeMapEntry;
-        typedef boost::bimap<std::string, StateType> StateTypeMap;
-        typedef StateTypeMap::value_type StateTypeMapEntry;
-
+        //! Initialises the command type map
         void init_command_type_map(void);
+
+        //! Initialises the state type map
         void init_state_type_map(void);
 
-        PcoCameraLinkController* controller_;
-        CommandTypeMap command_type_map_;
-        StateTypeMap state_type_map_;
-        boost::mutex state_transition_mutex_;
+        PcoCameraLinkController* controller_; //!< Pointer to controller instance
+        CommandTypeMap command_type_map_;     //!< Command type map
+        StateTypeMap state_type_map_;         //!< State type map
+        boost::mutex state_transition_mutex_; //!< State transition mutex
     };
 
+    //! IStateInfo - state information interface class
     struct IStateInfo
     {
+        // Returns the current state type value
         virtual PcoCameraState::StateType state_type(void) const = 0;
     };
+
+    //! State class definitions. These inherit from the boost statechart state base class
+    //! and implement the IStateInfo interface allowing the current state to be interrogated.
+    //! Each state class defines one or more custom reactions to legal transition events and
+    //! implements a react method for each of those transitions.
+
+    //! Disconnected - disconnected state class
+    //!
+    //! The disconnected state is the default state in the camera state machine, in which the
+    //! controller is not connected to the camera system.
+    //!
+    //! The following state transition events are supported:
+    //!    connect -> connected
 
     struct Disconnected : IStateInfo, sc::state<Disconnected, PcoCameraState>
     {
         public:
+            //! Defines reactions to legal events
             typedef sc::custom_reaction<EventConnect> reactions;
 
+            //! Constructor - initialises state machine context
             Disconnected(my_context ctx) : my_base(ctx) {};
 
+            //! Reacts to connect transition events
             sc::result react(const EventConnect&);
 
+            //! Returns the current state type
             PcoCameraState::StateType state_type(void) const
             {
                 return PcoCameraState::StateType::StateDisconnected;
             }
     };
 
+    //! Connected - connected state class
+    //!
+    //! The connected state is occupied when the controller is connected to the camera system
+    //! but the camera has not been configured and armed for image acquisition.
+    //!
+    //! The following state transition events are supported:
+    //!
+    //!    disconnect -> disconnected
+    //!    arm        -> armed
+
     struct Connected : IStateInfo, sc::state<Connected, PcoCameraState>
     {
         public:
+            //! Defines reactions to legal events
             typedef mpl::list<
                 sc::custom_reaction<EventDisconnect>,
                 sc::custom_reaction<EventArm>
             > reactions;
 
+            //! Constructor - initialises state machine context
             Connected(my_context ctx) : my_base(ctx) {};
 
+            //! Reacts to disconnect transition events
             sc::result react(const EventDisconnect&);
+            //! Reacts to arm transition events
             sc::result react(const EventArm&);
 
+            //! Returns the current state type
             PcoCameraState::StateType state_type(void) const
             {
                 return PcoCameraState::StateType::StateConnected;
@@ -167,34 +236,63 @@ namespace FrameReceiver
 
     };
 
+    //! Armed - armed state class
+    //!
+    //! The armed state is occupied when the controller has armed the camera system for image
+    //! acquisition, which commits configuration settings to the camera and prepares for image
+    //! acquisition.
+    //!
+    //! The following state transition events are supported:
+    //!
+    //!    disarm       -> connected
+    //!    record start -> recording
+
     struct Armed : IStateInfo, sc::state<Armed, PcoCameraState>
     {
         public:
-            typedef mpl::list<
+           //! Defines reactions to legal events
+           typedef mpl::list<
                 sc::custom_reaction<EventDisarm>,
                 sc::custom_reaction<EventRecordStart>
             > reactions;
 
+            //! Constructor - initialises state machine context
             Armed(my_context ctx) : my_base(ctx) {};
 
+            //! Reacts to disarm transition events
             sc::result react(const EventDisarm&);
+            //! Reacts to record start transition events
             sc::result react(const EventRecordStart&);
 
+            //! Returns the current state type
             PcoCameraState::StateType state_type(void) const
             {
                 return PcoCameraState::StateType::StateArmed;
             }
     };
 
+    //! Recording - recording state class
+    //!
+    //! The recording state is occupied when the controller has started the camera in recording
+    //! mode and images are being acquired.
+    //!
+    //! The following state transition events are supported:
+    //!
+    //!    record stop -> armed
+
     struct Recording : IStateInfo, sc::state<Recording, PcoCameraState>
     {
         public:
+            //! Defines reactions to legal events
             typedef sc::custom_reaction<EventRecordStop> reactions;
 
+            //! Constructor - initialises state machine context
             Recording(my_context ctx) : my_base(ctx) {};
 
+            //! Reacts to record stop transition events
             sc::result react(const EventRecordStop&);
 
+            //! Returns the current state type
             PcoCameraState::StateType state_type(void) const
             {
                 return PcoCameraState::StateType::StateRecording;

--- a/data/frameReceiver/include/PcoCameraStateMachine.h
+++ b/data/frameReceiver/include/PcoCameraStateMachine.h
@@ -2,7 +2,7 @@
  * PcoCameraStateMachine.h - finite state machine implementation for the PCO camera controller
  *
  * Created on: 22 Sept 2021
- *     Author: Tim Nicholls, STFC Detector Systems Group
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
  */
 
 #ifndef INCLUDE_PCOCAMERASTATEMACHINE_H_

--- a/data/frameReceiver/include/PcoCameraStatus.h
+++ b/data/frameReceiver/include/PcoCameraStatus.h
@@ -1,3 +1,13 @@
+/*!
+ * PcoCameraStatus.h - status parameter container for the PCO camera
+ *
+ * This class implements a status parameter container for the PCO camera, containing all the
+ * status parameters that are captured and reported to controlling clients.
+ *
+ * Created on: Sep 24, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
 #ifndef PCOCAMERASTATUS_H_
 #define PCOCAMERASTATUS_H_
 
@@ -6,30 +16,41 @@
 namespace FrameReceiver
 {
 
+    //! PcoCameraStatus - PCO camera status parameter container
     class PcoCameraStatus : public OdinData::ParamContainer
     {
 
         public:
+
+            //! Default constructor
+            //!
+            //! This constructor binds all the status parameters in the container, grouping
+            //! them as appropriate. This allows them to be accessed with the path-like set/get
+            //! mechanism implemented in ParamContainer.
+
             PcoCameraStatus()
             {
+                // Bind overall state parameters
                 bind_param<std::string>(camera_state_name_, "camera/state");
                 bind_param<bool>(acquiring_, "acquisition/acquiring");
                 bind_param<unsigned long>(frames_acquired_, "acquisition/frames_acquired");
 
+                // Bind camera info parameters
                 bind_param<std::string>(camera_name_, "camera/info/name");
                 bind_param<unsigned int>(camera_type_, "camera/info/type");
                 bind_param<unsigned long>(camera_serial_, "camera/info/serial");
             }
 
         private:
-            std::string camera_state_name_;
-            bool acquiring_;
-            unsigned long frames_acquired_;
+            std::string camera_state_name_;  //!< Name of the current camera state
+            bool acquiring_;                 //!< Flag if camera currently acquiring frames
+            unsigned long frames_acquired_;  //!< Number of frames acquired in current acqusition
 
-            std::string camera_name_;
-            unsigned int camera_type_;
-            unsigned long camera_serial_;
+            std::string camera_name_;        //!< Camera name
+            unsigned int camera_type_;       //!< Camera product type
+            unsigned long camera_serial_;    //!< Camera serial number
 
+            //! Allow the PcoCameraLinkController class direct access to status parameters
             friend class PcoCameraLinkController;
 
     };

--- a/data/frameReceiver/include/PcoCameraStatus.h
+++ b/data/frameReceiver/include/PcoCameraStatus.h
@@ -15,12 +15,20 @@ namespace FrameReceiver
                 bind_param<std::string>(camera_state_name_, "camera/state");
                 bind_param<bool>(acquiring_, "acquisition/acquiring");
                 bind_param<unsigned long>(frames_acquired_, "acquisition/frames_acquired");
+
+                bind_param<std::string>(camera_name_, "camera/info/name");
+                bind_param<unsigned int>(camera_type_, "camera/info/type");
+                bind_param<unsigned long>(camera_serial_, "camera/info/serial");
             }
 
         private:
             std::string camera_state_name_;
             bool acquiring_;
             unsigned long frames_acquired_;
+
+            std::string camera_name_;
+            unsigned int camera_type_;
+            unsigned long camera_serial_;
 
             friend class PcoCameraLinkController;
 

--- a/data/frameReceiver/include/PcoCameraStatus.h
+++ b/data/frameReceiver/include/PcoCameraStatus.h
@@ -33,6 +33,7 @@ namespace FrameReceiver
 
             PcoCameraStatus() :
                 camera_state_name_("unknown"),
+                rearm_required_(false),
                 acquiring_(false),
                 frames_acquired_(0),
                 error_code_(error_code_none),
@@ -43,6 +44,7 @@ namespace FrameReceiver
             {
                 // Bind overall state parameters
                 bind_param<std::string>(camera_state_name_, "camera/state");
+                bind_param<bool>(rearm_required_, "camera/rearm_required");
                 bind_param<bool>(acquiring_, "acquisition/acquiring");
                 bind_param<unsigned long>(frames_acquired_, "acquisition/frames_acquired");
 
@@ -69,6 +71,7 @@ namespace FrameReceiver
 
         private:
             std::string camera_state_name_;  //!< Name of the current camera state
+            bool rearm_required_;            //!< Indicates re-arm required due to config change
             bool acquiring_;                 //!< Flag if camera currently acquiring frames
             unsigned long frames_acquired_;  //!< Number of frames acquired in current acqusition
 

--- a/data/frameReceiver/include/PcoCameraStatus.h
+++ b/data/frameReceiver/include/PcoCameraStatus.h
@@ -16,6 +16,9 @@
 namespace FrameReceiver
 {
 
+    const unsigned long error_code_none = 0;
+    const std::string error_message_none = "no error";
+
     //! PcoCameraStatus - PCO camera status parameter container
     class PcoCameraStatus : public OdinData::ParamContainer
     {
@@ -28,12 +31,24 @@ namespace FrameReceiver
             //! them as appropriate. This allows them to be accessed with the path-like set/get
             //! mechanism implemented in ParamContainer.
 
-            PcoCameraStatus()
+            PcoCameraStatus() :
+                camera_state_name_("unknown"),
+                acquiring_(false),
+                frames_acquired_(0),
+                error_code_(error_code_none),
+                error_message_(error_message_none),
+                camera_name_("unknown"),
+                camera_type_(0),
+                camera_serial_(0)
             {
                 // Bind overall state parameters
                 bind_param<std::string>(camera_state_name_, "camera/state");
                 bind_param<bool>(acquiring_, "acquisition/acquiring");
                 bind_param<unsigned long>(frames_acquired_, "acquisition/frames_acquired");
+
+                // Bind error status parameters
+                bind_param<unsigned long>(error_code_, "camera/error/code");
+                bind_param<std::string>(error_message_, "camera/error/message");
 
                 // Bind camera info parameters
                 bind_param<std::string>(camera_name_, "camera/info/name");
@@ -41,10 +56,24 @@ namespace FrameReceiver
                 bind_param<unsigned long>(camera_serial_, "camera/info/serial");
             }
 
+            //! Resets the error status parameters
+            //!
+            //! This is a convenience method to allow the error status parameters to be reset to
+            //! their default "no error" state.
+
+            void reset_error_status(void)
+            {
+                error_code_ = error_code_none;
+                error_message_ = error_message_none;
+            }
+
         private:
             std::string camera_state_name_;  //!< Name of the current camera state
             bool acquiring_;                 //!< Flag if camera currently acquiring frames
             unsigned long frames_acquired_;  //!< Number of frames acquired in current acqusition
+
+            unsigned long error_code_;       //!< PCO camera error code
+            std::string error_message_;      //!< Camera error message
 
             std::string camera_name_;        //!< Camera name
             unsigned int camera_type_;       //!< Camera product type

--- a/data/frameReceiver/include/PcoCameraStatus.h
+++ b/data/frameReceiver/include/PcoCameraStatus.h
@@ -42,6 +42,24 @@ namespace FrameReceiver
                 camera_type_(0),
                 camera_serial_(0)
             {
+                bind_params();
+            }
+
+            //! Resets the error status parameters
+            //!
+            //! This is a convenience method to allow the error status parameters to be reset to
+            //! their default "no error" state.
+
+            void reset_error_status(void)
+            {
+                error_code_ = error_code_none;
+                error_message_ = error_message_none;
+            }
+
+        private:
+
+            void bind_params(void)
+            {
                 // Bind overall state parameters
                 bind_param<std::string>(camera_state_name_, "camera/state");
                 bind_param<bool>(rearm_required_, "camera/rearm_required");
@@ -58,18 +76,6 @@ namespace FrameReceiver
                 bind_param<unsigned long>(camera_serial_, "camera/info/serial");
             }
 
-            //! Resets the error status parameters
-            //!
-            //! This is a convenience method to allow the error status parameters to be reset to
-            //! their default "no error" state.
-
-            void reset_error_status(void)
-            {
-                error_code_ = error_code_none;
-                error_message_ = error_message_none;
-            }
-
-        private:
             std::string camera_state_name_;  //!< Name of the current camera state
             bool rearm_required_;            //!< Indicates re-arm required due to config change
             bool acquiring_;                 //!< Flag if camera currently acquiring frames

--- a/data/frameReceiver/src/CMakeLists.txt
+++ b/data/frameReceiver/src/CMakeLists.txt
@@ -24,7 +24,8 @@ if (PCOCAMERA_FOUND)
 		PcoCameraLinkController.cpp
 		PcoCameraStateMachine.cpp
 		PcoCameraDelayExposureConfig.cpp
-		ParamContainer.cpp)
+		ParamContainer.cpp
+		PcoCameraError.c)
 
 	target_include_directories(PcoCameraLinkFrameDecoder PRIVATE ${PCOCAMERA_INCLUDES})
 

--- a/data/frameReceiver/src/CMakeLists.txt
+++ b/data/frameReceiver/src/CMakeLists.txt
@@ -23,6 +23,7 @@ if (PCOCAMERA_FOUND)
 		PcoCameraLinkFrameDecoderLib.cpp
 		PcoCameraLinkController.cpp
 		PcoCameraStateMachine.cpp
+		PcoCameraDelayExposureConfig.cpp
 		ParamContainer.cpp)
 
 	target_include_directories(PcoCameraLinkFrameDecoder PRIVATE ${PCOCAMERA_INCLUDES})

--- a/data/frameReceiver/src/ParamContainer.cpp
+++ b/data/frameReceiver/src/ParamContainer.cpp
@@ -1,8 +1,26 @@
+/*!
+ * ParamContainer.cpp - parameter container class with JSON encoding/decoding
+ *
+ * This class implements a simple parameter container with JSON encoding/decoding, allowing
+ * applications to maintain e.g. configuration and status parameters with easy integration
+ * with external client control via JSON message payloads (e.g IpcMessage).
+ *
+ * Created on: Oct 7, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
 #include <sstream>
 #include "ParamContainer.h"
 
 namespace OdinData
 {
+
+//! Encodes the parameter container to a JSON-formatted string
+//!
+//! This method encodes the parameter container to a JSON-formatted string. The values of
+//! all bound parameters in the container are encoded into return JSON string.
+//!
+//! \return JSON-encoded string of all bound parameters in the container
 
 std::string ParamContainer::encode(void)
 {
@@ -18,18 +36,32 @@ std::string ParamContainer::encode(void)
     return encoded;
 }
 
+//! Encodes the parameter container into an existing document
+//!
+//! This method encodes the paramter container into a JSON document, using the specified path
+//! as a prefix for all parameter paths. The values of all bound parameters are encoded into
+//! the document.
+//!
+//! \param doc_obj - reference to the JSON document to encode parameters into
+//! \param prefix_path - string to prefix to the path of all bound parameters
+
 void ParamContainer::encode(ParamContainer::Document& doc_obj, std::string prefix_path)
 {
+    // Construct the JSON pointer prefix based on the prefix path
     std::string pointer_prefix = pointer_path("");
     if (!prefix_path.empty())
     {
-        pointer_prefix += prefix_path; // + "/";
+        pointer_prefix += prefix_path;
+
+        // Ensure that the pointer prefix is correctly terminated with a trailing slash.
         if (*pointer_prefix.rbegin() != '/')
         {
             pointer_prefix += "/";
         }
     }
 
+    // Iterate through all the bound paramters in the getter map, retreiving their current
+    // values and setting in the JSON document.
     for (GetterFuncMap::iterator it = getter_map_.begin(); it != getter_map_.end(); ++it)
     {
         rapidjson::Value value_obj;
@@ -39,31 +71,61 @@ void ParamContainer::encode(ParamContainer::Document& doc_obj, std::string prefi
     }
 }
 
+//! Updates the values of parameters from the specified JSON-formatted string
+//!
+//! This method updates the values of the parameters from the specfied JSON-formatted string.
+//! Parameters in the string that do not correspond to bound parameters in the container are
+//! ignored.
+//!
+//! \param json - JSON-formatted string to update parameters from
 
 void ParamContainer::update(std::string json)
 {
     update(json.c_str());
 }
 
+//! Updates the values of parameters from the specified JSON-formatted character array
+//!
+//! This method updates the values of the parameters from the specfied JSON-formatted character.
+//! array. Parameters in the array that do not correspond to bound parameters in the container are
+//! ignored.
+//!
+//! \param json - pointer to a JSON-formatted character array to update parameters from
+
 void ParamContainer::update(const char* json)
 {
+    // Parse the JSON argument into the document
     doc_.Parse(json);
+
+    // Throw an informative exception of parse errors were encountered
     if (doc_.HasParseError())
     {
         std::stringstream ss;
-        ss << "JSON parse error updating configuration from string at offset " 
+        ss << "JSON parse error updating configuration from string at offset "
             << doc_.GetErrorOffset() ;
         ss << " : " << rapidjson::GetParseError_En(doc_.GetParseError());
         throw ParamContainerException(ss.str());
     }
 
+    // Update parameters in the container from the parsed JSON document
     update(doc_);
 }
 
+//! Updates the values of the parameters from the specified JSON document
+//!
+//! This method updates the values of the parameters from the specfied JSON document object.
+//! Parameters in the document that do not correspond to bound parameters in the container are
+//! ignored.
+//!
+//! \param json - reference to a JSON document obhect to update paramters from
+
 void ParamContainer::update(ParamContainer::Document& doc_obj)
 {
+    // Iterate through all bound parameters in the setter function map
     for (SetterFuncMap::iterator it = setter_map_.begin(); it != setter_map_.end(); ++it)
     {
+        // If the path of the bound parameter is found in the JSON document, call the setter
+        // function to update the value of the parameter
         if (rapidjson::Value* value_ptr = rapidjson::Pointer(
             pointer_path((*it).first).c_str()).Get(doc_obj)
         )
@@ -72,6 +134,9 @@ void ParamContainer::update(ParamContainer::Document& doc_obj)
         }
     }
 }
+
+// Explicit specialisations of the set_value and get_value methods, mapping native attribute types
+// to the appropriate RapidJSON storage type.
 
 template<> int ParamContainer::set_value(rapidjson::Value& value_obj) const
 {
@@ -94,6 +159,8 @@ template<> void ParamContainer::get_value(unsigned int& param, rapidjson::Value&
 }
 
 #ifdef __APPLE__
+// The MacOS clang compiler seems to base uint64 on a different base type than gcc on Linux, causing
+// linker errors with templated specialisations of get_value and set_value for unsigned long.
 template<> unsigned long ParamContainer::set_value(rapidjson::Value& value_obj) const
 {
   return value_obj.GetUint64();

--- a/data/frameReceiver/src/PcoCameraDelayExposureConfig.cpp
+++ b/data/frameReceiver/src/PcoCameraDelayExposureConfig.cpp
@@ -1,0 +1,199 @@
+/*!
+ * PcoCameraDelayExposureConfig.cpp - PCO camera delay and exposure configuration container
+ *
+ * This class implements a container for the PCO camera delay and exposure configuration settings,
+ * allowing them to easily be calculated and related to exposure time and frame rate. The camera
+ * expresses these in terms of a time value and timebase unit for each of exposure and delay
+ * parameters.
+ *
+ * Created on: Oct 20, 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
+#include "PcoCameraDelayExposureConfig.h"
+
+namespace FrameReceiver
+{
+
+    //! Default constructor for PcoCameraDelayExposure
+    //!
+    //! This default constructor simply initialises all attributes of the class to zero
+    //! initial values
+    PcoCameraDelayExposure::PcoCameraDelayExposure() :
+        exposure_time_(0),
+        delay_time_(0),
+        exposure_timebase_(0),
+        delay_timebase_(0)
+    { }
+
+    //! Constructor taking exposure time and frame rate values as arguments.
+    //!
+    //! The constructor initialises the PcoCameraDelayExposure based on the specified exposure
+    //! time and frame rate arguments, calculating the appropriate exposure and delay time and
+    //! timebase setting values.
+    //!
+    //! \param exposure_time - double precision exposure time in seconds
+    //! \param frame_rate    - double precision frame rate in Hertz
+
+    PcoCameraDelayExposure::PcoCameraDelayExposure(double exposure_time, double frame_rate)
+    {
+        // Calculate the exposure timebase and time from the specified value
+        exposure_timebase_ = select_timebase(exposure_time);
+        exposure_time_ = static_cast<DWORD>(exposure_time / timebase_value(exposure_timebase_));
+
+        // Calculate the frame period and delay time based on the specified rate and exposure time
+        double frame_period = 1.0 / frame_rate;
+        double delay_time = frame_period - exposure_time;
+
+        // Calculate the approproate delay timebase and time value
+        delay_timebase_ = select_timebase(delay_time);
+        delay_time_ = static_cast<DWORD>(delay_time / timebase_value(delay_timebase_));
+    }
+
+    //! Returns the exposure timebase unit as a string
+    //!
+    //! This method returns the exposure timebase unit as a string.
+    //!
+    //! \return timebase unit name as a string
+
+    const std::string PcoCameraDelayExposure::exposure_timebase_unit(void) {
+        return timebase_name(exposure_timebase_);
+    }
+
+    //! Returns the delay timebase unit as a string
+    //!
+    //! This method returns the delay timebase unit as a string.
+    //!
+    //! \return timebase unit name as a string
+
+    const std::string PcoCameraDelayExposure::delay_timebase_unit(void) {
+        return timebase_name(delay_timebase_);
+    }
+
+    //! Returns the exposure time in seconds as a double
+    //!
+    //! This method calculated and returns the exposure time in seconds as a double.
+    //!
+    //! \return exposure time in seconds as a double
+
+    double PcoCameraDelayExposure::exposure_time(void) {
+        return (exposure_time_ * timebase_value(exposure_timebase_));
+    }
+
+    //! Returns the frame rate in Hertz as a double
+    //!
+    //! This method calculated and returns the frame rate in Hertz as a double.
+    //!
+    //! \return frame rate in Hertz as a double
+
+    double PcoCameraDelayExposure::frame_rate(void) {
+        return 1.0 / (exposure_time() + (delay_time_ * timebase_value(delay_timebase_)));
+    }
+
+    //! Equality operator
+    //!
+    //! The method implements the equality operator for the PcoCameraDelayExposure class,
+    //! comparing each of the exposure and delay time and timebase values.
+    //!
+    //! \param other - reference to other PcoCameraDelayExposure object being compared
+    //! \return bool equality, true when all fields match
+
+    bool PcoCameraDelayExposure::operator==(const PcoCameraDelayExposure& other
+    )
+    {
+        return (
+            (exposure_time_ == other.exposure_time_) &&
+            (delay_time_ == other.delay_time_) &&
+            (exposure_timebase_== other.exposure_timebase_) &&
+            (delay_timebase_ == other.delay_timebase_)
+        );
+    }
+
+    // Private methods
+
+    //! Returns the timebase value in seconds for the specified timebase
+    //!
+    //! This private method returns the timebase value in seconds for a given timebase
+    //! value.
+    //!
+    //! \param timebase - timebase to determine value for
+    //! \return timebase value in seconds as a double
+
+    const double PcoCameraDelayExposure::timebase_value(unsigned int timebase)
+    {
+        double value = 0.0;
+
+        if (timebase_value_map_.size() == 0)
+        {
+            timebase_value_map_[TimebaseNs] = 1.0E-9;
+            timebase_value_map_[TimebaseUs] = 1.0E-6;
+            timebase_value_map_[TimebaseMs] = 1.0E-3;
+        }
+
+        if (timebase_value_map_.count((PcoCameraTimebase)timebase))
+        {
+            value = timebase_value_map_[(PcoCameraTimebase)timebase];
+        }
+        return value;
+    }
+
+    //! Returns the timebase name as a string for the specified timebase
+    //!
+    //! This private method returns the name of a the specified timebase as a string
+    //!
+    //! \param timebase - timebase setting
+    //! \return name of the timebase setting as a string
+
+    const std::string PcoCameraDelayExposure::timebase_name(unsigned int timebase)
+    {
+        std::string name = "??";
+
+        if (timebase_name_map_.size() == 0)
+        {
+            timebase_name_map_[TimebaseNs] = "ns";
+            timebase_name_map_[TimebaseUs] = "us";
+            timebase_name_map_[TimebaseMs] = "ms";
+        }
+
+        if (timebase_name_map_.count((PcoCameraTimebase)timebase))
+        {
+            name = timebase_name_map_[(PcoCameraTimebase)timebase];
+        }
+        return name;
+    }
+
+    //! Selects the appropriate timebase value for a specified desired time value
+    //!
+    //! This private method selects the appropriate timebase for the specified time value (i.e. for
+    //! either exposure or delay settings.)
+    //!
+    //! \param time_value time value in seconds
+    //! \return appropriate timebase setting or unknown if no legal setting possible
+
+    PcoCameraDelayExposure::PcoCameraTimebase PcoCameraDelayExposure::select_timebase(
+        double time_value
+    )
+    {
+        PcoCameraTimebase timebase = PcoCameraTimebase::TimebaseUnknown;
+
+        // Select appropriate exposure timebase - TODO handle max/min exposure limits
+        if (time_value < timebase_value(PcoCameraTimebase::TimebaseUs))
+        {
+            timebase = PcoCameraTimebase::TimebaseNs;
+        }
+        else if (time_value < timebase_value(PcoCameraTimebase::TimebaseMs))
+        {
+            timebase = PcoCameraTimebase::TimebaseUs;
+        }
+        else
+        {
+            timebase = PcoCameraTimebase::TimebaseMs;
+        }
+
+        return timebase;
+    }
+
+    // Static declaration of timebase value and name maps
+    PcoCameraDelayExposure::TimebaseValueMap PcoCameraDelayExposure::timebase_value_map_;
+    PcoCameraDelayExposure::TimebaseNameMap PcoCameraDelayExposure::timebase_name_map_;
+}

--- a/data/frameReceiver/src/PcoCameraError.c
+++ b/data/frameReceiver/src/PcoCameraError.c
@@ -1,0 +1,30 @@
+/*
+ * PcoCameraError.c - PCO camera error message implementation
+ *
+ * This module implements a simple wrapper around the PCO SDK error text implementation. It is
+ * not possible to call this directly from C++ modules due to non-ISO standard use of character
+ * arrays in the error lookups in PCO_errt.h.
+ *
+ * Created on: 03 Nov 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdarg.h>
+
+// Reimplementation of non-ANSI standard sprintf_s function used by the PCO SDK
+int sprintf_s(char* buf, int size, const char* cp, ...)
+{
+    va_list arglist;
+
+    va_start(arglist, cp);
+    return vsnprintf(buf, size, cp, arglist);
+}
+
+// Include the PCO error text header with the appropriate define to get PCO_GetErrorText is
+// defined
+#define PCO_ERRT_H_CREATE_OBJECT
+#include "defs.h"
+#include "PCO_errt.h"
+

--- a/data/frameReceiver/src/PcoCameraLinkController.cpp
+++ b/data/frameReceiver/src/PcoCameraLinkController.cpp
@@ -374,6 +374,22 @@ bool PcoCameraLinkController::connect(void)
         << " frame rate: " << camera_config_.frame_rate_ << "Hz"
     );
 
+    // Check if the camera has been left in a recording state and stop if necssary
+    WORD recording_state;
+    pco_error = camera_->PCO_GetRecordingState(&recording_state);
+    if (!check_pco_error("Failed to get current recording state", pco_error))
+    {
+        return false;
+    }
+    if (recording_state == recording_state_running)
+    {
+        LOG4CXX_INFO(logger_, "Camera recording state is running, setting to stopped");
+        pco_error = camera_->PCO_SetRecordingState(recording_state_stopped);
+        if (!check_pco_error("Failed to set recording state to stopped", pco_error))
+        {
+            return false;
+        }
+    }
     return true;
 }
 
@@ -436,7 +452,7 @@ bool PcoCameraLinkController::start_recording(void)
 
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Setting camera recording state to running");
 
-    pco_error = camera_->PCO_SetRecordingState(1);
+    pco_error = camera_->PCO_SetRecordingState(recording_state_running);
     camera_recording_ =
         check_pco_error("Failed to set camera recoding state to running", pco_error);
 
@@ -485,7 +501,7 @@ bool PcoCameraLinkController::stop_recording(void)
     }
 
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Setting camera recording state to stopped");
-    pco_error = camera_->PCO_SetRecordingState(0);
+    pco_error = camera_->PCO_SetRecordingState(recording_state_stopped);
     recording_stopped &=
         check_pco_error("Failed to set camera recoding state to stopped", pco_error);
 

--- a/data/frameReceiver/src/PcoCameraLinkController.cpp
+++ b/data/frameReceiver/src/PcoCameraLinkController.cpp
@@ -8,7 +8,7 @@
  * client connection.
  *
  * Created on: 20 July 2021
- *     Author: Tim Nicholls, STFC Detector Systems Group
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
  */
 
 #include <math.h>
@@ -16,6 +16,7 @@
 #include "PcoCameraLinkController.h"
 #include "PcoCameraStateMachine.h"
 #include "PcoCameraLinkFrameDecoder.h"
+#include "PcoCameraError.h"
 #include "file12.h"
 #include "IpcMessage.h"
 #include "InairaDefinitions.h"
@@ -725,4 +726,25 @@ int PcoCameraLinkController::image_nr_from_timestamp(void *image_buffer, int shi
         pixel_ptr++;
     }
     return image_num;
+}
+
+//! Returns a readable error string for a camera error code.
+//!
+//! This method translates a PCO camera error code into text, wrapping the PCO_GetErrorText
+//! method exposed from the SDK.
+//!
+//! \param pco_error - PCO camera error code
+//! \return error text as a string
+
+std::string PcoCameraLinkController::pco_error_text(DWORD pco_error)
+{
+    // Allocate a char buffer to receive the error text
+    const unsigned int err_buf_size = 100;
+    char err_buf[err_buf_size];
+
+    // Pass the error code and text buffer to the SDK function
+    PCO_GetErrorText(pco_error, err_buf, err_buf_size);
+
+    // Return the error text as a string
+    return std::string(err_buf);
 }

--- a/data/frameReceiver/src/PcoCameraLinkController.cpp
+++ b/data/frameReceiver/src/PcoCameraLinkController.cpp
@@ -1,3 +1,16 @@
+/*
+ * PcoCameraLinkControllercpp - controller class for the PCO camera integration into odin-data
+ *
+ * This class implements a controller for the PCO camera. The controller is responsible for the
+ * control of the PCO camera within the frame decoder and runs a service thread that implements
+ * the image acquisition loop. The controller maintains configuration and status parameters that
+ * are accessible to the frame decoder and manages state transitions under command of the decoder
+ * client connection.
+ *
+ * Created on: 20 July 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Group
+ */
+
 #include <math.h>
 
 #include "PcoCameraLinkController.h"
@@ -9,15 +22,22 @@
 
 using namespace FrameReceiver;
 
+//! PcoCameraLinkController constructor
+//!
+//! This constructor initialises the camera controller, setting up the initial state and
+//! configuration of the camera. In order for the decoder to report the image dimensions during
+//! frame receiver configuration, the camera is connected, armed and started so that the image
+//! width and height can be obtained from the frame grabber.
+//!
+//! \param decoder - pointer to the parent frame decoder
+
 PcoCameraLinkController::PcoCameraLinkController(PcoCameraLinkFrameDecoder* decoder) :
     logger_(Logger::getLogger("FR.PcoCLController")),
     decoder_(decoder),
     camera_state_(this),
     camera_opened_(false),
     grabber_opened_(false),
-    camera_running_(false),
-    camera_num_(0),
-    grabber_timeout_ms_(10000),
+    camera_recording_(false),
     image_width_(0),
     image_height_(0),
     image_data_type_(2) // TODO Get this from common header?
@@ -50,8 +70,27 @@ PcoCameraLinkController::PcoCameraLinkController(PcoCameraLinkFrameDecoder* deco
     LOG4CXX_INFO(logger_, "Grabber reports actual size: width: "
         << image_width_ << " height: " << image_height_);
 
+    // Stop the camera recording
     camera_state_.execute_command(PcoCameraState::CommandStopRecording);
 }
+
+//! Destructor for the controller class
+//!
+//! This is the PcoCameraLinkController destructor, which ensures that the connection to the
+//! camera and grabber is cleaned up corectly on destruction, by calling the diconnect method
+
+PcoCameraLinkController::~PcoCameraLinkController()
+{
+    this->disconnect();
+}
+
+
+//! Executes a camera control command
+//!
+//! This method exectures a camera control command, passing the specified command to the camera
+//! state machine to trigger the appropriate action.
+//!
+//! \param command - string command name to execute
 
 void PcoCameraLinkController::execute_command(std::string& command)
 {
@@ -67,11 +106,29 @@ void PcoCameraLinkController::execute_command(std::string& command)
     LOG4CXX_INFO(logger_, "Camera state is now: " << camera_state_.current_state_name());
 }
 
+//! Updates the configuration of the camera from a parameter document
+//!
+//! This method updates the configuration parameters of the controller from the specifed parameter
+//! document (i.e. JSON parameter payload from an IpcMessage command received by the decoder). The
+//! configuration parameter container is updated and then new delay/exposure parameters derived as
+//! appropriate, triggering an update to the camera setttings.
+//!
+//! \param params - JSON parameter document to update configuration from
+
 void PcoCameraLinkController::update_configuration(ParamContainer::Document& params)
 {
+    // Update the camera configuration with the specified parameters
     camera_config_.update(params);
 
+    // Create a new delay/exposure configuration based on updated settings
     PcoCameraDelayExposure new_delay_exp(camera_config_.exposure_time_, camera_config_.frame_rate_);
+
+    // If this delay/exposure configuration differs from the current settings, update the camera
+    // parameters accordingly. Note that if the camera is recording this will cause an immediate
+    // change in the frame rate and exposure time. If not, the camera must be re-armed to commit
+    // those settings.
+    // TODO - if camera is not recording, flag that a re-arm is needed or disarm the camera if
+    // necessary
     if (new_delay_exp != camera_delay_exp_)
     {
         LOG4CXX_DEBUG_LEVEL(2, logger_, "Updating camera delay and exposure settings");
@@ -79,6 +136,7 @@ void PcoCameraLinkController::update_configuration(ParamContainer::Document& par
         DWORD pco_error;
         bool updated = true;
 
+        // Set the delay and exposure timebases
         pco_error = camera_->PCO_SetTimebase(
             new_delay_exp.delay_timebase_, new_delay_exp.exposure_timebase_
         );
@@ -89,6 +147,7 @@ void PcoCameraLinkController::update_configuration(ParamContainer::Document& par
                 updated = false;
         }
 
+        // Set the delay and exposure times
         pco_error = camera_->PCO_SetDelayExposure(
             new_delay_exp.delay_time_, new_delay_exp.exposure_time_
         );
@@ -106,10 +165,27 @@ void PcoCameraLinkController::update_configuration(ParamContainer::Document& par
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Camera config num_frames is now " << camera_config_.num_frames_)
 }
 
-void PcoCameraLinkController::get_configuration(ParamContainer::Document& params)
+//! Gets the current configuration of the camera.
+//!
+//! This method gets the current configuration of the camera from the configuration parameter
+//! container, encoding it into the specified JSON document at the specified path.
+//!
+//! \param params - JSON document to encode config params into
+//! \param param_prefix - string prefix to encode parameters with
+
+void PcoCameraLinkController::get_configuration(ParamContainer::Document& params,
+    const std::string param_prefix)
 {
-    camera_config_.encode(params, "camera");
+    camera_config_.encode(params, param_prefix);
 }
+
+//! Gets the current status of the camera.
+//!
+//! This method gets the current status of the camera from the status parameter container,
+//! encoding it into the specified JSON document at the specified path.
+//!
+//! \param params - JSON document to encode status params into
+//! \param param_prefix - string prefix to encode parameters with
 
 void PcoCameraLinkController::get_status(ParamContainer::Document& params,
     const std::string param_prefix)
@@ -118,30 +194,43 @@ void PcoCameraLinkController::get_status(ParamContainer::Document& params,
     camera_status_.encode(params, param_prefix);
 }
 
+//! Disconnects from the camera.
+//!
+//! This method disconnects from the PCO camera and grabber and is invoked by the camera state
+//! machine on receipt of the appropriate command.
+
 void PcoCameraLinkController::disconnect(void)
 {
-    if (camera_)
-    {
-        LOG4CXX_INFO(logger_, "Disconnecting camera");
+    LOG4CXX_INFO(logger_, "Disconnecting camera");
 
-        if (camera_running_) {
-            LOG4CXX_DEBUG_LEVEL(2, logger_, "Disconnect: setting camera recording state to stop");
-            this->stop_recording();
-        }
+    // Stop the camera recording if necessary
+    if (camera_ && camera_recording_) {
+        LOG4CXX_DEBUG_LEVEL(2, logger_, "Disconnect: setting camera recording state to stop");
+        this->stop_recording();
+    }
 
-        if (grabber_ && grabber_opened_) {
-            LOG4CXX_DEBUG_LEVEL(2, logger_, "Disconnect: closing PCO grabber");
-            grabber_->Close_Grabber();
-            grabber_opened_ = false;
-        }
+    // Close the grabber connection and delete the instance
+    if (grabber_ && grabber_opened_) {
+        LOG4CXX_DEBUG_LEVEL(2, logger_, "Disconnect: closing PCO grabber");
+        grabber_->Close_Grabber();
+        grabber_opened_ = false;
+        grabber_.reset();
+    }
 
-        if (camera_opened_) {
-            LOG4CXX_DEBUG_LEVEL(2, logger_, "Disconnect: closing PCO camera");
-            camera_->Close_Cam();
-            camera_opened_ = false;
-        }
+    // Close the camera connection and delete the instance
+    if (camera_ && camera_opened_) {
+        LOG4CXX_DEBUG_LEVEL(2, logger_, "Disconnect: closing PCO camera");
+        camera_->Close_Cam();
+        camera_opened_ = false;
+        camera_.reset();
     }
 }
+
+//! Connects to the camera.
+//!
+//! This method connects to the PCO camera and initialises the state of the controller. Camera and
+//! grabber instances are created and opened, and various configuration and status values read
+//! back from the system to synchronise the controller with the camera.
 
 void PcoCameraLinkController::connect(void)
 {
@@ -154,7 +243,8 @@ void PcoCameraLinkController::connect(void)
 
     LOG4CXX_INFO(logger_, "Connecting camera");
 
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Creating PCO camera object")
+    // Create a new PCO camera instance
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Creating PCO camera instance")
     camera_.reset(new CPco_com_clhs());
     if (camera_ == NULL)
     {
@@ -164,8 +254,9 @@ void PcoCameraLinkController::connect(void)
 
     }
 
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Opening PCO camera " << camera_num_);
-    pco_error = camera_->Open_Cam(camera_num_);
+    // Open the camera connection
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Opening PCO camera " << camera_config_.camera_num_);
+    pco_error = camera_->Open_Cam(camera_config_.camera_num_);
     if (pco_error != PCO_NOERROR)
     {
         LOG4CXX_ERROR(logger_, "Failed to open PCO camera with error code 0x"
@@ -178,16 +269,8 @@ void PcoCameraLinkController::connect(void)
         camera_opened_ = true;
     }
 
-    pco_error = camera_->PCO_GetCameraType(&camera_type, &camera_serial);
-    if (pco_error != PCO_NOERROR)
-    {
-        LOG4CXX_ERROR(logger_, "Failed to get camera type with error code 0x"
-            << std::hex << pco_error << std::dec);
-        this->disconnect();
-        return;
-    }
-
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Creating PCO grabber object")
+    // Create a new grabber instance
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Creating PCO grabber instance")
     grabber_.reset(new CPco_grab_clhs((CPco_com_clhs*)(camera_.get())));
     if (grabber_ == NULL)
     {
@@ -196,8 +279,9 @@ void PcoCameraLinkController::connect(void)
         return;
     }
 
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Opening PCO grabber " << camera_num_);
-    pco_error = grabber_->Open_Grabber(camera_num_);
+    // Open the grabber connection
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Opening PCO grabber " << camera_config_.camera_num_);
+    pco_error = grabber_->Open_Grabber(camera_config_.camera_num_);
     if (pco_error != PCO_NOERROR)
     {
         LOG4CXX_ERROR(logger_, "Failed to open PCO grabber with error code 0x"
@@ -210,7 +294,11 @@ void PcoCameraLinkController::connect(void)
         grabber_opened_ = true;
     }
 
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Setting grabber timeout to " << grabber_timeout_ms_ << "ms");
+    // Set the grabber image acquisition timeout
+    int grabber_timeout_ms_ = static_cast<int>(camera_config_.image_timeout_ * 1000);
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Setting grabber image timeout to "
+        << grabber_timeout_ms_ << "ms"
+    );
     pco_error = grabber_->Set_Grabber_Timeout(grabber_timeout_ms_);
     if (pco_error != PCO_NOERROR)
     {
@@ -220,7 +308,20 @@ void PcoCameraLinkController::connect(void)
         return;
     }
 
-    LOG4CXX_DEBUG_LEVEL(2, logger_, "Getting camera info");
+
+    // Read the camera type and serial number
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Getting camera type and serial number");
+    pco_error = camera_->PCO_GetCameraType(&camera_type, &camera_serial);
+    if (pco_error != PCO_NOERROR)
+    {
+        LOG4CXX_ERROR(logger_, "Failed to get camera type with error code 0x"
+            << std::hex << pco_error << std::dec);
+        this->disconnect();
+        return;
+    }
+
+    // Read the camera descriptor to determine the dynamic resolution and pixel data size
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Getting camera descriptor");
     pco_error = camera_->PCO_GetCameraDescriptor(&camera_description);
     if (pco_error != PCO_NOERROR)
     {
@@ -234,6 +335,8 @@ void PcoCameraLinkController::connect(void)
         camera_description.wDynResDESC << " pixel size: " << image_pixel_size_ << " bytes"
     );
 
+    // Read the camera information string o get the camera name
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Getting camera information string");
     pco_error = camera_->PCO_GetInfo(1, camera_infostr, sizeof(camera_infostr));
     if (pco_error != PCO_NOERROR)
     {
@@ -243,6 +346,7 @@ void PcoCameraLinkController::connect(void)
         return;
     }
 
+    // Populate the camera status container with the appropriate information
     camera_status_.camera_name_ = std::string(camera_infostr);
     camera_status_.camera_type_ = camera_type;
     camera_status_.camera_serial_ = camera_serial;
@@ -252,6 +356,8 @@ void PcoCameraLinkController::connect(void)
         << " serial number: " << camera_serial
     );
 
+    // Read the camera delay and exposure settings
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Getting camera delay and exposure times");
     pco_error = camera_->PCO_GetDelayExposure(
         &(camera_delay_exp_.delay_time_), &(camera_delay_exp_.exposure_time_)
     );
@@ -263,6 +369,8 @@ void PcoCameraLinkController::connect(void)
         return;
     }
 
+    // Read the camera delay and exposure timebase settings
+    LOG4CXX_DEBUG_LEVEL(2, logger_, "Getting camera delay and exposure timebase");
     pco_error = camera_->PCO_GetTimebase(
         &(camera_delay_exp_.delay_timebase_), &(camera_delay_exp_.exposure_timebase_)
     );
@@ -274,6 +382,7 @@ void PcoCameraLinkController::connect(void)
         return;
     }
 
+    // Update the camera exposure and frame rate in the configuration container accordingly
     camera_config_.exposure_time_ = camera_delay_exp_.exposure_time();
     camera_config_.frame_rate_ = camera_delay_exp_.frame_rate();
 
@@ -285,10 +394,17 @@ void PcoCameraLinkController::connect(void)
 
 }
 
+//! Arms the camera, preparing for recording
+//!
+//! This method arms the PCO camera and is invoked by the camera state machine on receipt of the
+//! appropriate command. Arming is necessary to commit new settings to the camera for image
+//! recording.
+
 void PcoCameraLinkController::arm(void)
 {
     DWORD pco_error;
 
+    // Arm the camera
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Arming camera");
     pco_error = camera_->PCO_ArmCamera();
     if (pco_error != PCO_NOERROR)
@@ -299,6 +415,7 @@ void PcoCameraLinkController::arm(void)
         return;
     }
 
+    // Post-arm the grabber
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Post-arming grabber");
     pco_error = grabber_->PostArm();
     if (pco_error != PCO_NOERROR)
@@ -310,10 +427,21 @@ void PcoCameraLinkController::arm(void)
     }
 }
 
+//! Disarms the camera
+//!
+//! This method diarms the PCO camera and is invoked by the camera state machine on receipt of the
+//! appropriate command. Disarming the camera is a logic-only operation within the
+//! state machine - no camera operations are necessary.
+
 void PcoCameraLinkController::disarm(void)
 {
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Disarming camera");
 }
+
+//! Starts the camera recording, allowing images to be acquired.
+//!
+//! This method sets the camera recording state to true, allowing images to be acquired, and is
+//! invoked by the camera state machine on receipt of the appropriate command.
 
 void PcoCameraLinkController::start_recording(void)
 {
@@ -331,8 +459,13 @@ void PcoCameraLinkController::start_recording(void)
         return;
     }
 
-    camera_running_ = true;
+    camera_recording_ = true;
 }
+
+//! Stops the camera recording.
+//!
+//! This method sets the camera recording state to false, stopping images acquisition, and is
+//! invoked by the camera state machine on receipt of the appropriate command.
 
 void PcoCameraLinkController::stop_recording(void)
 {
@@ -347,140 +480,206 @@ void PcoCameraLinkController::stop_recording(void)
         this->disconnect();
         return;
     }
-    camera_running_ = false;
+    camera_recording_ = false;
 }
+
+//! Runs the camera control loop service
+//!
+//! This method runs the camera control loop service and is invoked in a separate thread by the
+//! frame decoder instance. The service is responsible for image acquisiton when the camera is
+//! recording and for determining if the current acqusition has completed the appropriate number
+//! of frames. When the camera is not recording, the service runs in a idle tick.
 
 void PcoCameraLinkController::run_camera_service(void)
 {
 
-  camera_status_.acquiring_ = false;
-  camera_status_.frames_acquired_ = 0;
+    DWORD pco_error;
 
-  int timeout = 0;
-  DWORD pco_error;
+    // Initialise acquistion status parameters
+    camera_status_.acquiring_ = false;
+    camera_status_.frames_acquired_ = 0;
 
-  while (decoder_->run_camera_service_thread())
-  {
-    if (camera_running_)
+    // Calculate intial image timeout in milliseconds from configuration
+    int image_timeout_ms = static_cast<int>(camera_config_.image_timeout_);
+
+    // Loop while the decoder indicates the camera service should run
+    while (decoder_->run_camera_service_thread())
     {
-
-      if (!camera_status_.acquiring_)
-      {
-
-        grabber_->Get_Grabber_Timeout(&timeout);
-
-        pco_error = grabber_->Start_Acquire();
-        if (pco_error != PCO_NOERROR)
+        // If the camera is recording, handle image acquisition
+        if (camera_recording_)
         {
-            LOG4CXX_ERROR(logger_, "Failed to start frame grabber acquisition error code 0x"
-                << std::hex << pco_error << std::dec);
-        }
+            // If the camera state is now set to recording but we have not yet enabled acquisition
+            // in the grabber, do so now
+            if (!camera_status_.acquiring_)
+            {
 
-        std::stringstream ss;
-        if (camera_config_.num_frames_)
-        {
-            ss << camera_config_.num_frames_;
+                // Recalculate image timeout in milliseconds
+                image_timeout_ms = static_cast<int>(camera_config_.image_timeout_ * 1000);
+
+                // Start acquisition on the grabber
+                pco_error = grabber_->Start_Acquire();
+                if (pco_error != PCO_NOERROR)
+                {
+                    LOG4CXX_ERROR(logger_, "Failed to start frame grabber acquisition error code 0x"
+                        << std::hex << pco_error << std::dec);
+                }
+
+                std::stringstream ss;
+                if (camera_config_.num_frames_)
+                {
+                    ss << camera_config_.num_frames_;
+                }
+                else
+                {
+                    ss << "unlimited";
+                }
+                LOG4CXX_DEBUG_LEVEL(1, logger_,
+                    "Camera controller now acquiring " << ss.str() << " frames");
+                camera_status_.acquiring_ = true;
+                camera_status_.frames_acquired_ = 0;
+            }
+
+            // Request an empty buffer from the decoder and acquire an image into it
+            int buffer_id;
+            void* buffer_addr;
+            if (decoder_->get_empty_buffer(buffer_id, buffer_addr))
+            {
+                LOG4CXX_DEBUG_LEVEL(2, logger_, "Decoder got empty buffer id " << buffer_id
+                    << " at addr 0x" << std::hex << (unsigned long)buffer_addr << std::dec );
+
+                // Get a pointer to the image location in the buffer, o.e. offset from the start
+                // of the buffer by the header size
+                void* image_buffer = reinterpret_cast<void*>(
+                    reinterpret_cast<uint8_t*>(buffer_addr) + decoder_->get_frame_header_size()
+                );
+
+                // Acquire an image from the camera into the buffer
+                if (this->acquire_image(image_buffer, image_timeout_ms))
+                {
+                    // Populate the fields of the frame header
+                    Inaira::FrameHeader* frame_hdr =
+                        reinterpret_cast<Inaira::FrameHeader*>(buffer_addr);
+                    frame_hdr->frame_number = camera_status_.frames_acquired_;
+                    frame_hdr->frame_width = image_width_;
+                    frame_hdr->frame_height = image_height_;
+                    frame_hdr->frame_data_type = image_data_type_;
+                    frame_hdr->frame_size = get_image_size();
+
+                    // Notify the frame receiver main control thread that the frame is ready to
+                    // be processed downstream
+                    decoder_->notify_frame_ready(buffer_id, camera_status_.frames_acquired_);
+                    camera_status_.frames_acquired_++;
+                }
+            }
+            else
+            {
+                // The logic of handling when no buffers are available needs improving with
+                // retry attempts, but for now simply report the failure as a warning
+                LOG4CXX_WARN(logger_, "Failed to get empty buffer from queue");
+            }
+
+            // If the current configuration specifies a number of frames to acquire, check if
+            // that has been reached and, if so, stop the acquisition
+            if (camera_config_.num_frames_ &&
+                (camera_status_.frames_acquired_ >= camera_config_.num_frames_))
+            {
+                pco_error = grabber_->Stop_Acquire();
+                if (pco_error != PCO_NOERROR)
+                {
+                    LOG4CXX_ERROR(logger_,
+                        "Failed to stop frame grabber acquisition with error code 0x"
+                        << std::hex << pco_error << std::dec);
+                }
+                LOG4CXX_INFO(logger_,
+                    "Camera controller completed acquisition of "
+                    << camera_status_.frames_acquired_ << " frames"
+                );
+                camera_status_.acquiring_ = false;
+                camera_state_.execute_command(PcoCameraState::CommandType::CommandStopRecording);
+            }
         }
         else
         {
-            ss << "unlimited";
+            // Idle loop for when the camera is not recording. If acquisition has just completed
+            // report the number of frames acquired
+            if (camera_status_.acquiring_)
+            {
+                LOG4CXX_DEBUG_LEVEL(1, logger_, "Camera controller finished acquiring after "
+                    << camera_status_.frames_acquired_ << " frames");
+                camera_status_.acquiring_ = false;
+            }
+            usleep(1000);
         }
-        LOG4CXX_DEBUG_LEVEL(1, logger_, "Camera controller now acquiring " << ss.str() << " frames");
-        camera_status_.acquiring_ = true;
-        camera_status_.frames_acquired_ = 0;
-      }
-
-      int buffer_id;
-      void* buffer_addr;
-      if (decoder_->get_empty_buffer(buffer_id, buffer_addr))
-      {
-        LOG4CXX_DEBUG_LEVEL(2, logger_, "Decoder got empty buffer id " << buffer_id
-          << " at addr 0x" << std::hex << (unsigned long)buffer_addr << std::dec );
-
-        void* image_buffer = reinterpret_cast<void*>(
-          reinterpret_cast<uint8_t*>(buffer_addr) + decoder_->get_frame_header_size()
-        );
-
-        if (this->acquire_image(image_buffer, timeout))
-        {
-          Inaira::FrameHeader* frame_hdr = reinterpret_cast<Inaira::FrameHeader*>(buffer_addr);
-          frame_hdr->frame_number = camera_status_.frames_acquired_;
-          frame_hdr->frame_width = image_width_;
-          frame_hdr->frame_height = image_height_;
-          frame_hdr->frame_data_type = image_data_type_;
-          frame_hdr->frame_size = get_image_size();
-
-          decoder_->notify_frame_ready(buffer_id, camera_status_.frames_acquired_);
-          camera_status_.frames_acquired_++;
-        }
-      }
-      else
-      {
-        LOG4CXX_WARN(logger_, "Failed to get empty buffer from queue");
-      }
-      if (camera_config_.num_frames_ && (camera_status_.frames_acquired_ >= camera_config_.num_frames_))
-      {
-        pco_error = grabber_->Stop_Acquire();
-        if (pco_error != PCO_NOERROR)
-        {
-            LOG4CXX_ERROR(logger_, "Failed to stop frame grabber acquisition with error code 0x"
-                << std::hex << pco_error << std::dec);
-        }
-        LOG4CXX_INFO(logger_,
-            "Camera controller completed acquisition of " << camera_status_.frames_acquired_ << " frames"
-        );
-        camera_status_.acquiring_ = false;
-        camera_state_.execute_command(PcoCameraState::CommandType::CommandStopRecording);
-      }
-      else
-      {
-        //usleep(1000000); // TODO remove this hardcoded delay
-      }
     }
-    else
-    {
-      if (camera_status_.acquiring_)
-      {
-        LOG4CXX_DEBUG_LEVEL(1, logger_, "Camera controller finished acquiring after "
-          << camera_status_.frames_acquired_ << " frames");
-        camera_status_.acquiring_ = false;
-      }
-      usleep(1000);
-    }
-  }
-
 }
+
+//! Returns the name of the current camera state
+//!
+//! This method returns the readable name of the current state of the camera state machine
+//!
+//! \return current state name as a string
 
 std::string PcoCameraLinkController::camera_state_name(void)
 {
     return camera_state_.current_state_name();
 }
 
-PcoCameraLinkController::~PcoCameraLinkController()
-{
-    this->disconnect();
-}
+//! Returns the camera image width in number of pixels
+//!
+//! This method returns the width of the camera image as an integer number of pixels
+//!
+//! \return the camera image width in pixels as an unsigned integer
 
 uint32_t PcoCameraLinkController::get_image_width(void)
 {
     return image_width_;
 }
 
+//! Returns the camera image height in number of pixels.
+//!
+//! This method returns the height of the camera image as an integer number of pixels.
+//!
+//! \return the camera image height in pixels as an unsigned integer
+
 uint32_t PcoCameraLinkController::get_image_height(void)
 {
     return image_height_;
 }
+
+//! Returns the camera image data type required for the frame header parameters.
+//!
+//! This method returns the image data type, as required for frame header parameters.
+//!
+//! \return image data type as in integer
 
 int PcoCameraLinkController::get_image_data_type(void)
 {
     return image_data_type_;
 }
 
+//! Returns the camera image size in bytes
+//!
+//! This method calculates and returns the size of the camera image in bytes, based on the
+//! image dimensions and pixel data size read from the camera during initialisation
+//!
+//! \return camera image size in bytes
+
 std::size_t PcoCameraLinkController::get_image_size(void)
 {
     std::size_t image_size = image_width_ * image_height_ * image_pixel_size_;
     return image_size;
 }
+
+// Private methods
+
+//! Acquires an image from camera into an image buffer
+//!
+//! This method acquires an image from the camera, reading it into the specified image buffer. THe
+//! return value indicates if the acquisition succeeded.
+//!
+//! \param image_buffer - void pointer to the location in the buffer to receive the image
+//! \param timeout - image acquisition timeout in milliseconds
+//! \return boolean flag indicating if the acquisition succeeded
 
 bool PcoCameraLinkController::acquire_image(void* image_buffer, int timeout)
 {
@@ -505,19 +704,25 @@ bool PcoCameraLinkController::acquire_image(void* image_buffer, int timeout)
     return acquire_ok;
 }
 
-int PcoCameraLinkController::image_nr_from_timestamp(void *buf,int shift)
-{
-  unsigned short *b;
-  int y;
-  int image_nr=0;
-  b=(unsigned short *)(buf);
+//! Calculates the image number from the timestamp in the first pixel data
+//!
+//! This method, taken from an example in the PCO SDK demo applications, calculates the camera
+//! image number from the BCD coded values stored in the first four pixels of the image.
+//!
+//! \param image_buffer - pointer to image buffer in memory
+//! \param shift - number of bits to right-shift each BCD pixel value
+//! \return image number as an integer
 
-  y=100*100*100;
-  for(;y>0;y/=100)
-  {
-   *b>>=shift;
-   image_nr+= (((*b&0x00F0)>>4)*10 + (*b&0x000F))*y;
-   b++;
-  }
-  return image_nr;
+int PcoCameraLinkController::image_nr_from_timestamp(void *image_buffer, int shift)
+{
+    int image_num = 0;
+    unsigned short *pixel_ptr = (unsigned short *)(image_buffer);
+
+    for (int bcd_mult = 100*100*100; bcd_mult > 0; bcd_mult /= 100)
+    {
+        *pixel_ptr >>= shift;
+        image_num += (((*pixel_ptr & 0x00F0)>>4)*10 + (*pixel_ptr & 0x000F)) * bcd_mult ;
+        pixel_ptr++;
+    }
+    return image_num;
 }

--- a/data/frameReceiver/src/PcoCameraLinkFrameDecoder.cpp
+++ b/data/frameReceiver/src/PcoCameraLinkFrameDecoder.cpp
@@ -169,10 +169,10 @@ void PcoCameraLinkFrameDecoder::configure(
   OdinData::IpcMessage& config_msg, OdinData::IpcMessage& config_reply
 )
 {
-  if (config_msg.has_param("camera"))
+  if (config_msg.has_param(CAMERA_CONFIG_PATH))
   {
     ParamContainer::Document config_params;
-    config_msg.encode_params(config_params, "camera");
+    config_msg.encode_params(config_params, CAMERA_CONFIG_PATH);
     controller_->update_configuration(config_params);
   }
 
@@ -194,7 +194,7 @@ void PcoCameraLinkFrameDecoder::request_configuration(
 
   //rapidjson::Document camera_config;
   ParamContainer::Document camera_config;
-  controller_->get_configuration(camera_config);
+  controller_->get_configuration(camera_config, CAMERA_CONFIG_PATH);
   config_reply.update(camera_config);
 }
 

--- a/data/frameReceiver/src/PcoCameraLinkFrameDecoder.cpp
+++ b/data/frameReceiver/src/PcoCameraLinkFrameDecoder.cpp
@@ -1,8 +1,9 @@
 /*
+ * PcoCameraLinkFrameDecoder.cpp - frame decoder implementation for the PCO camera system
  *
- * PcoCameraLinkFrameDecoder.cpp
- *
- * odin-data frame decoder plugin for image capture from PCO CameraLink systems
+ * This class implements the odin-data frame decoder plugin for image capture from PCO CameraLink
+ * systems. The decoder provides the standard interface between the frame receiver infrastructure
+ * and the PCO camera controller instance, which controls image acquisition.
  *
  * Created on: 20 July 2021
  *     Author: Tim Nicholls, STFC Detector Systems Software Group
@@ -15,6 +16,12 @@
 
 using namespace FrameReceiver;
 
+//! Constructor for the PcoCameraLinkFrameDecoder class.
+//!
+//! This constructor performs the basic initialisation of the decoder instance. The base class
+//! constructor is called and the logger instance initialised. The detailed initialisation of the
+//! decoder and the PCO camera controller is done later during a call to the init() method.
+
 PcoCameraLinkFrameDecoder::PcoCameraLinkFrameDecoder() :
     FrameDecoderCameraLink()
 {
@@ -23,36 +30,80 @@ PcoCameraLinkFrameDecoder::PcoCameraLinkFrameDecoder() :
     LOG4CXX_INFO(logger_, "PcoCameraLinkFrameDecoder version " << this->get_version_long() << " loaded");
 }
 
-// Destructor for PcoCameraLinkFrameDecoder
+//! Destructor for PcoCameraLinkFrameDecoder class.
 PcoCameraLinkFrameDecoder::~PcoCameraLinkFrameDecoder()
 {
    LOG4CXX_DEBUG_LEVEL(2, logger_, "PcoCameraLinkFrameDecoder cleanup");
 }
+
+//! Returns the decoder version number major value.
+//!
+//! This method returns the major part of the decoder version number, which is derived from the
+//! most recent git tag and commit history.
+//!
+//! \return major version number as an integer
 
 int PcoCameraLinkFrameDecoder::get_version_major()
 {
   return ODIN_DATA_VERSION_MAJOR;
 }
 
+//! Returns the decoder version number minor value.
+//!
+//! This method returns the minor part of the decoder version number, which is derived from the
+//! most recent git tag and commit history.
+//!
+//! \return minor version number as an integer
+
 int PcoCameraLinkFrameDecoder::get_version_minor()
 {
   return ODIN_DATA_VERSION_MINOR;
 }
+
+//! Returns the decoder version number patch value.
+//!
+//! This method returns the patch part of the decoder version number, which is derived from the
+//! most recent git tag and commit history.
+//!
+//! \return patch version number as an integer
 
 int PcoCameraLinkFrameDecoder::get_version_patch()
 {
   return ODIN_DATA_VERSION_PATCH;
 }
 
+//! Returns the decoder version short string.
+//!
+//! This method returns the short version of the formatted version number as a string. This is
+//! derived from the most recent git tag and version history.
+//!
+//! \return decoder short version as a string
+
 std::string PcoCameraLinkFrameDecoder::get_version_short()
 {
   return ODIN_DATA_VERSION_STR_SHORT;
 }
 
+//! Returns the decoder version long string.
+//!
+//! This method returns the long version of the formatted version number as a string. This is
+//! derived from the most recent git tag and version history
+//!
+//! \return decoder long version as a string
+
 std::string PcoCameraLinkFrameDecoder::get_version_long()
 {
   return ODIN_DATA_VERSION_STR;
 }
+
+//! Initialises the decoder from a configuration message provided by the frame receiver.
+//!
+//! This method initialises the decoder from the configuration message received as an argument. The
+//! base class init() method is called and a new PcoCameraLinkController instance created to control
+//! the camera.
+//!
+//! \param logger - deprecated argument retained for compatiblity
+//! \param config_msg - IPC message containing decoder configuration parameters
 
 void PcoCameraLinkFrameDecoder::init(LoggerPtr& logger, OdinData::IpcMessage& config_msg)
 {
@@ -61,9 +112,18 @@ void PcoCameraLinkFrameDecoder::init(LoggerPtr& logger, OdinData::IpcMessage& co
   // Pass the configuration message to the base class decoder
   FrameDecoderCameraLink::init(config_msg);
 
+  // Instantiate a new camera controller
   controller_.reset(new PcoCameraLinkController(this));
 
 }
+
+//! Returns the frame buffer size required for image acquisition.
+//!
+//! This method calcualtes and returns the frame buffer size required for image acqusition. This is
+//! used by the frame reeiver controller during initialisation to configure the frame shared memory
+//! buffer. The controller determines the raw image size based on the configuration of the camera.
+//!
+//! \return frame buffer size in bytes
 
 const size_t PcoCameraLinkFrameDecoder::get_frame_buffer_size(void) const
 {
@@ -72,21 +132,43 @@ const size_t PcoCameraLinkFrameDecoder::get_frame_buffer_size(void) const
   return frame_buffer_size;
 }
 
+//! Returns the frame header size defined for this decoder.
+//!
+//! This method returns the size of the frame header used during image acqusition by this decoder.
+//!
+//! \return frame header size in bytes
+
 const size_t PcoCameraLinkFrameDecoder::get_frame_header_size(void) const
 {
   return sizeof(Inaira::FrameHeader);
 }
 
+//! Monitors the state of allocated buffers in the decoder.
+//!
+//! This method is intended to monitor the state of currently allocated buffers in the decoder and
+//! release any timed-out buffers. In practice this is not currently implemented in this decoder
+//! since the success of image acquisition is known immediately, rather than having to handle the
+//! situation where packet loss occurs.
+
 void PcoCameraLinkFrameDecoder::monitor_buffers(void)
 {
-
+  // Currently does nothing
 }
+
+//! Handles camera control channel messages.
+//!
+//! This method handles messages received on the camera control channel, decoding the incoming
+//! IpcMessages and dispatching operations to appropriate method as necessary.
 
 void PcoCameraLinkFrameDecoder::handle_ctrl_channel(void)
 {
+
+  // Receive the control channel request and store the client identity so that the response
+  // can be routed back correctly.
   std::string client_identity;
   std::string ctrl_req_encoded = ctrl_channel_.recv(&client_identity);
 
+  // Create a reply message
   IpcMessage ctrl_reply;
   IpcMessage::MsgVal ctrl_reply_val = IpcMessage::MsgValIllegal;
 
@@ -95,19 +177,27 @@ void PcoCameraLinkFrameDecoder::handle_ctrl_channel(void)
 
   try
   {
+
+    // Attempt to decode the incoming message and get the request type and value
     IpcMessage ctrl_req(ctrl_req_encoded.c_str(), false);
     IpcMessage::MsgType req_type = ctrl_req.get_msg_type();
     IpcMessage::MsgVal req_val = ctrl_req.get_msg_val();
 
+    // Pre-populate the appropriate fields in the response
     ctrl_reply.set_msg_id(ctrl_req.get_msg_id());
     ctrl_reply.set_msg_type(OdinData::IpcMessage::MsgTypeAck);
+    ctrl_reply.set_msg_val(req_val);
 
+    // Handle the request according to its type
     switch (req_type)
     {
+      // Handle command reqests
       case IpcMessage::MsgTypeCmd:
 
+        // Handle command requests according to their value
         switch (req_val)
         {
+          // Handle a configuration command
           case IpcMessage::MsgValCmdConfigure:
             LOG4CXX_DEBUG_LEVEL(3, logger_,
               "Got camera control configure request from client " << client_identity
@@ -116,6 +206,7 @@ void PcoCameraLinkFrameDecoder::handle_ctrl_channel(void)
             this->configure(ctrl_req, ctrl_reply);
             break;
 
+          // Handle a configuration request command
           case IpcMessage::MsgValCmdRequestConfiguration:
             LOG4CXX_DEBUG_LEVEL(3, logger_,
               "Got camera control read configuration request from client " << client_identity
@@ -124,6 +215,7 @@ void PcoCameraLinkFrameDecoder::handle_ctrl_channel(void)
             this->request_configuration(std::string(""), ctrl_reply);
             break;
 
+          // Handle a status request command
           case IpcMessage::MsgValCmdStatus:
             LOG4CXX_DEBUG_LEVEL(3, logger_,
               "Got camera control status request from client " << client_identity
@@ -132,6 +224,7 @@ void PcoCameraLinkFrameDecoder::handle_ctrl_channel(void)
             this->get_status(std::string(""), ctrl_reply);
             break;
 
+          // Handle unsupported request values by setting the status and error message
           default:
             request_ok = false;
             error_ss << "Illegal command request value: " << req_val;
@@ -139,21 +232,24 @@ void PcoCameraLinkFrameDecoder::handle_ctrl_channel(void)
         }
         break;
 
+      // Handle unsupported request types by setting the status and error message
       default:
         request_ok = false;
         error_ss << "Illegal command request type: " << req_type;
         break;
     }
-
-    ctrl_reply.set_msg_val(req_val);
-
   }
+
+  // Handle exceptions thrown during message decoding, setting the status and error message
+  // accordingly
   catch (IpcMessageException& e)
   {
     request_ok = false;
     error_ss << e.what();
   }
 
+  // If the request could not be decoded or handled, set the response type to NACK and populate
+  // the error parameter with the error string
   if (!request_ok) {
     LOG4CXX_ERROR(logger_, "Error handling camera control channel request from client "
                   << client_identity << ": " << error_ss.str());
@@ -161,14 +257,29 @@ void PcoCameraLinkFrameDecoder::handle_ctrl_channel(void)
     ctrl_reply.set_param<std::string>("error", error_ss.str());
   }
 
+  // Send the encoded response back to the client
   ctrl_channel_.send(ctrl_reply.encode(), 0, client_identity);
 
 }
+
+//! Configures the decoder and camera based on the content of a configuration message.
+//!
+//! This method is called in response to receipt of a configuration command message on the
+//! control channel. If the message parameter payload includes camera parameters, these are
+//! passed to the camera controller for handling. If the payload contains a command parameter,
+//! this is passed to the controller to be executed.
+//!
+//! TODO - handle failure cases here so that response to client is updated
+//!
+//! \param config_msg - incoming configuration IPC message
+//! \param config_reply - reply to configuration message, currently unused
 
 void PcoCameraLinkFrameDecoder::configure(
   OdinData::IpcMessage& config_msg, OdinData::IpcMessage& config_reply
 )
 {
+  // If the configuration message has camera parameters, copy those into a parameter document
+  // and tell the controller to update its configuration
   if (config_msg.has_param(CAMERA_CONFIG_PATH))
   {
     ParamContainer::Document config_params;
@@ -176,14 +287,24 @@ void PcoCameraLinkFrameDecoder::configure(
     controller_->update_configuration(config_params);
   }
 
-  if (config_msg.has_param("command"))
+  // If the configuration message has a command parameter, extract the command value and pass
+  // to the controller
+  if (config_msg.has_param(CAMERA_COMMAND_PATH))
   {
-    std::string command = config_msg.get_param<std::string>("command");
+    std::string command = config_msg.get_param<std::string>(CAMERA_COMMAND_PATH);
     LOG4CXX_DEBUG_LEVEL(2, logger_, "Config request has command: " << command);
     controller_->execute_command(command);
   }
 }
 
+//! Returns the current camera configuration parameters in an IPC message.
+//!
+//! This method is called in response to a configuration request message received on the
+//! control channel. The reply is populated with the current configuration parameters from
+//! the base class and from the camera controller.
+//!
+//! \param param_prefix - parameter prefix for reply as a string
+//! \param config_reply - reference to config reply message to populate
 void PcoCameraLinkFrameDecoder::request_configuration(
   const std::string param_prefix, OdinData::IpcMessage& config_reply
 )
@@ -192,30 +313,47 @@ void PcoCameraLinkFrameDecoder::request_configuration(
   // Call the base class method to populate parameters
   FrameDecoderCameraLink::request_configuration(param_prefix, config_reply);
 
-  //rapidjson::Document camera_config;
+  // Create a new param document and pass to the controller to populate with the appropriate
+  // parameter prefix
   ParamContainer::Document camera_config;
-  controller_->get_configuration(camera_config, CAMERA_CONFIG_PATH);
+  std::string camera_config_prefix = param_prefix + CAMERA_CONFIG_PATH;
+  controller_->get_configuration(camera_config, camera_config_prefix);
+
+  // Update the reply message parameters with the config document
   config_reply.update(camera_config);
 }
 
-void PcoCameraLinkFrameDecoder::get_status(const std::string param_prefix,
-    OdinData::IpcMessage& status_msg)
+//! Returns the current status of the camera in an IPC message.
+//!
+//! This method is called in response to a status request received on the control channel. The
+//! reply is populated with current status parameters retrieved from the controller.
+//!
+//! \param param_prefix - parameter prefix for reply as a string
+//! \param status_reply - reference to status reply message to populate
+
+void PcoCameraLinkFrameDecoder::get_status(
+  const std::string param_prefix, OdinData::IpcMessage& status_reply
+)
 {
 
-  status_msg.set_param(param_prefix + "name", std::string("PcoCameraLinkFrameDecoder"));
+  // Insert the decoder name into the reply
+  status_reply.set_param(param_prefix + "name", std::string("PcoCameraLinkFrameDecoder"));
 
-  // std::string camera_prefix = param_prefix + "camera1/";
-  // status_msg.set_param(camera_prefix + "state", controller_->camera_state_name());
-
-  // std::string acq_prefix = param_prefix + "acquisition1/";
-  // status_msg.set_param(acq_prefix + "acquiring", controller_->is_acquiring());
-  // status_msg.set_param(acq_prefix + "frames_acquired", controller_->frames_acquired());
-
+  // Create a new parame document and pass to the controller to populate with the appropriate
+  // parameter prefix
   ParamContainer::Document camera_status;
   controller_->get_status(camera_status, param_prefix);
-  status_msg.update(camera_status);
+
+  // Update the reply message parameters with the status document
+  status_reply.update(camera_status);
 }
 
+// Private methods
+
+//! Runs the camera control service.
+//!
+//! This method runs the camera control service by calling the equivalent method in the controller
+//! which is responsible for controlling the camera and acquiring images
 
 void PcoCameraLinkFrameDecoder::run_camera_service(void)
 {

--- a/data/frameReceiver/src/PcoCameraStateMachine.cpp
+++ b/data/frameReceiver/src/PcoCameraStateMachine.cpp
@@ -1,3 +1,15 @@
+/*
+ * PcoCameraStateMachine.cpp - finite state machine implementation for the PCO camera controller
+ *
+ * This class implements a finite state machine handing for the PCO camera controller. This
+ * is based on the boost StartChart library. The camera state responds to known commands
+ * passed to the controller by a client and reacts accordingly, executing state transitions and
+ * triggering operations in the controller.
+ *
+ * Created on: 22 Sept 2021
+ *     Author: Tim Nicholls, STFC Detector Systems Group
+ */
+
 #include <iostream>
 #include <sstream>
 #include "PcoCameraStateMachine.h"
@@ -5,9 +17,17 @@
 
 using namespace FrameReceiver;
 
+//! Constructor for the PcoCameraState class.
+//!
+//! This constructor initialises the state machine, defining custom type information for the
+//! transition events.
+//!
+//! \param controller - pointer to the PCO controller instance, which acts on state transitions
+
 PcoCameraState::PcoCameraState(PcoCameraLinkController* controller) :
     controller_(controller)
 {
+    // Define custom type information for naming state transition events
     EventDisconnect::custom_static_type_ptr("disconnect");
     EventConnect::custom_static_type_ptr("connect");
     EventArm::custom_static_type_ptr("arm");
@@ -16,29 +36,58 @@ PcoCameraState::PcoCameraState(PcoCameraLinkController* controller) :
     EventRecordStop::custom_static_type_ptr("stop");
 }
 
+//! Executes a state transition command.
+//!
+//! This method executes the specified state transition command. Specified as a pointer to a char
+//! array, the command name is converted to a string and passed to the overloaded execute_command
+//! method.
+//!
+//! \param command - command name as a character array pointer
+
 void PcoCameraState::execute_command(const char* command)
 {
     std::string cmd_str(command);
     this->execute_command(cmd_str);
 }
 
+//! Executes a state transition command.
+//!
+//! This method executes the specified state transition command. Specified as a pointer to a char
+//! array, the command name is mapped to the command type value and passed to the overloaded
+//! execute_command method.
+//!
+//! \param command - command name as string reference
+
 void PcoCameraState::execute_command(std::string& command)
 {
+    // Map the specified command to a type value
     CommandType command_type = map_command_to_type(command);
 
+    // If the command is not recognised, throw an exception
     if (command_type == CommandUnknown)
     {
         std::stringstream ss;
         ss << "Unknown camera state transition command: " << command;
         throw(PcoCameraStateUnknownCommand(ss.str()));
     }
+
+    // Otherwise execute the command
     this->execute_command(command_type);
 }
 
+//! Executes a state transition command.
+//!
+//! This method executes the specified state transition command. THe command type specified as an
+//! argument is mapped to appropriate transition event, which is then procssed.
+//!
+//! \param command - state transition command type valuet
+
 void PcoCameraState::execute_command(PcoCameraState::CommandType command)
 {
+    // Acquire the transition lock to prevent concurrent access
     boost::lock_guard<boost::mutex> transition_lock(state_transition_mutex_);
 
+    // Process the appropriate transition event based on the command value
     switch (command)
     {
         case CommandConnect:
@@ -63,6 +112,7 @@ void PcoCameraState::execute_command(PcoCameraState::CommandType command)
             // Deliberate fall-through
         default:
             {
+                // If an illegal or unknown command value is specified, throw an exception
                 std::stringstream ss;
                 ss << "Unknown camera state transition command type: " << (int)command;
                 throw(PcoCameraStateUnknownCommand(ss.str()));
@@ -71,23 +121,45 @@ void PcoCameraState::execute_command(PcoCameraState::CommandType command)
     }
 }
 
-void PcoCameraState::unconsumed_event(const sc::event_base& e)
+//! Handles unconsumed, i.e. invalid, state transition events.
+//!
+//! This method is called when a state transition event is not consumed by the state machine, that
+//! is when an transition is requested that is not valid in the current state. An illegal transition
+//! exception is formatted with a relevent error string and thrown.
+//!
+//! \param event - reference to the unconsumed event
+
+void PcoCameraState::unconsumed_event(const sc::event_base& event)
 {
+    // Format an appropriate error message
     std::stringstream ss;
-    ss << e.custom_dynamic_type_ptr<char>() << " is not valid in "
+    ss << event.custom_dynamic_type_ptr<char>() << " is not valid in "
         << current_state_name() << " state";
+
+    // Throw an illegal transition exception
     throw(PcoCameraStateIllegalTransition(ss.str()));
 }
 
+//! Maps a command name string to a command type value
+//!
+//! This method maps a specified command name string to the appropriate command type, handling
+//! unknown strings by returning a value of CommandUnknown.
+//!
+//! \param command - reference to the command name as a string
+//! \return enumerated command type value
+
 PcoCameraState::CommandType PcoCameraState::map_command_to_type(std::string& command)
 {
+    // Set default return value
     CommandType command_type = CommandUnknown;
 
+    // Initialise the command type map if empty
     if (command_type_map_.size() == 0)
     {
         init_command_type_map();
     }
 
+    // If the specified command is present in the map, set the command type accordingly
     if (command_type_map_.left.count(command))
     {
         command_type = command_type_map_.left.at(command);
@@ -95,15 +167,26 @@ PcoCameraState::CommandType PcoCameraState::map_command_to_type(std::string& com
     return command_type;
 }
 
+//! Maps a state type to a state name.
+//!
+//! This methos maps an enumerated state type to a state name. Unknown state types return a
+//! string name of unknown.
+//!
+//! \param state_type - state type value
+//! \return state name as a string
+
 std::string PcoCameraState::map_state_to_name(StateType state_type)
 {
+    // Set default return value
     std::string state_name = "unknown";
 
+    // Initialise the command state map if empty
     if (state_type_map_.size() == 0)
     {
         init_state_type_map();
     }
 
+    // If the specified state is present in the map, set the state name accordingly
     if (state_type_map_.right.count(state_type))
     {
         state_name = state_type_map_.right.at(state_type);
@@ -111,15 +194,33 @@ std::string PcoCameraState::map_state_to_name(StateType state_type)
     return state_name;
 }
 
+// Returns the current state name.
+//!
+//! This method returns the current state name as a string.
+//!
+//! \return current state name as a string
+
 std::string PcoCameraState::current_state_name(void)
 {
     return map_state_to_name(current_state());
 }
 
+//! Returns the current state type.
+//!
+//! This method returns the current state type value by calling the state_type interface method
+//! on the current state object.
+//!
+//! \return current state type value
+
 PcoCameraState::StateType PcoCameraState::current_state(void)
 {
     return state_cast<const IStateInfo&>().state_type();
 }
+
+//! Initialises the command type map.
+//!
+//! This method initialises the entries in the command type map, which maps command names to
+//! enumerated command type values.
 
 void PcoCameraState::init_command_type_map(void)
 {
@@ -131,6 +232,11 @@ void PcoCameraState::init_command_type_map(void)
     command_type_map_.insert(CommandTypeMapEntry("stop",       CommandStopRecording));
 }
 
+//! Initialises the state type map.
+//!
+//! This method initialises the entries in the state type map, which maps state names to
+//! enumerated state type values.
+
 void PcoCameraState::init_state_type_map(void)
 {
     state_type_map_.insert(StateTypeMapEntry("disconnected", StateDisconnected));
@@ -139,11 +245,25 @@ void PcoCameraState::init_state_type_map(void)
     state_type_map_.insert(StateTypeMapEntry("recording",    StateRecording));
 }
 
+//! Reacts to connect transition events
+//!
+//! This method reacts to connect transition events in the disconnected state. The controller
+//! connect method is called and the state transits to connected.
+//!
+//! \param reference to connect event
+
 sc::result Disconnected::react(const EventConnect&)
 {
     outermost_context().controller_->connect();
     return transit<Connected>();
 }
+
+//! Reacts to disconnect transition events
+//!
+//! This method reacts to disconnect transition events in the connected state. The controller
+//! disconnect method is called and the state transits to disconnected.
+//!
+//! \param reference to disconnect event
 
 sc::result Connected::react(const EventDisconnect&)
 {
@@ -151,11 +271,25 @@ sc::result Connected::react(const EventDisconnect&)
     return transit<Disconnected>();
 }
 
+//! Reacts to arm transition events
+//!
+//! This method reacts to arm transition events in the connected state. The controller arm method
+//! is called and the state transits to armed.
+//!
+//! \param reference to connect event
+
 sc::result Connected::react(const EventArm&)
 {
     outermost_context().controller_->arm();
     return transit<Armed>();
 }
+
+//! Reacts to disarm transition events
+//!
+//! This method reacts to disarm transition events in the armed state. The controller disarm method
+//! is called and the state transits to connected.
+//!
+//! \param reference to connect event
 
 sc::result Armed::react(const EventDisarm&)
 {
@@ -163,11 +297,25 @@ sc::result Armed::react(const EventDisarm&)
     return transit<Connected>();
 }
 
+//! Reacts to record start transition events
+//!
+//! This method reacts to record state transition events in the conarmednected state. The controller
+//! start_recording method is called and the state transits to recording.
+//!
+//! \param reference to connect event
+
 sc::result Armed::react(const EventRecordStart&)
 {
     outermost_context().controller_->start_recording();
     return transit<Recording>();
 }
+
+//! Reacts to record stop transition events
+//!
+//! This method reacts to record stop transition events in the recording state. The controller
+//! stop_recording state is called and the state transits to armed.
+//!
+//! \param reference to connect event
 
 sc::result Recording::react(const EventRecordStop&)
 {

--- a/data/frameReceiver/src/PcoCameraStateMachine.cpp
+++ b/data/frameReceiver/src/PcoCameraStateMachine.cpp
@@ -7,7 +7,7 @@
  * triggering operations in the controller.
  *
  * Created on: 22 Sept 2021
- *     Author: Tim Nicholls, STFC Detector Systems Group
+ *     Author: Tim Nicholls, STFC Detector Systems Software Group
  */
 
 #include <iostream>

--- a/data/frameReceiver/src/PcoCameraStateMachine.cpp
+++ b/data/frameReceiver/src/PcoCameraStateMachine.cpp
@@ -32,6 +32,7 @@ PcoCameraState::PcoCameraState(PcoCameraLinkController* controller) :
     EventConnect::custom_static_type_ptr("connect");
     EventArm::custom_static_type_ptr("arm");
     EventDisarm::custom_static_type_ptr("disarm");
+    EventRearm::custom_static_type_ptr("rearm");
     EventRecordStart::custom_static_type_ptr("start");
     EventRecordStop::custom_static_type_ptr("stop");
     EventReset::custom_static_type_ptr("reset");
@@ -102,6 +103,9 @@ void PcoCameraState::execute_command(PcoCameraState::CommandType command)
             break;
         case CommandDisarm:
             process_event(EventDisarm());
+            break;
+        case CommandRearm:
+            process_event(EventRearm());
             break;
         case CommandStartRecording:
             process_event(EventRecordStart());
@@ -232,6 +236,7 @@ void PcoCameraState::init_command_type_map(void)
     command_type_map_.insert(CommandTypeMapEntry("disconnect", CommandDisconnect));
     command_type_map_.insert(CommandTypeMapEntry("arm",        CommandArm));
     command_type_map_.insert(CommandTypeMapEntry("disarm",     CommandDisarm));
+    command_type_map_.insert(CommandTypeMapEntry("rearm",      CommandRearm));
     command_type_map_.insert(CommandTypeMapEntry("start",      CommandStartRecording));
     command_type_map_.insert(CommandTypeMapEntry("stop",       CommandStopRecording));
     command_type_map_.insert(CommandTypeMapEntry("reset",      CommandReset));
@@ -323,6 +328,26 @@ sc::result Armed::react(const EventDisarm&)
     if (outermost_context().controller_->disarm())
     {
         return transit<Connected>();
+    }
+    else
+    {
+        return transit<Error>();
+    }
+}
+
+//! Reacts to rearm transition events
+//!
+//! This method reacts to rearm transition events in the armed state. The controller arm method
+//! is called and the state remains armed. If the rearm call fails the state transits to
+//! error.
+//!
+//! \param reference to rearm event
+
+sc::result Armed::react(const EventRearm&)
+{
+    if (outermost_context().controller_->arm())
+    {
+        return discard_event();
     }
     else
     {

--- a/data/tools/python/src/inaira/data/camera_control.py
+++ b/data/tools/python/src/inaira/data/camera_control.py
@@ -313,6 +313,15 @@ def disarm(ctx):
 
 @cli.command()
 @click.pass_context
+def rearm(ctx):
+    """Rearm the PCO camera.\f
+
+    :param ctx: command execution context
+    """
+    ctx.obj["controller"].do_command("rearm")
+
+@cli.command()
+@click.pass_context
 def start(ctx):
     """Start frame acquisition on the PCO camera.\f
 

--- a/data/tools/python/src/inaira/data/camera_control.py
+++ b/data/tools/python/src/inaira/data/camera_control.py
@@ -319,6 +319,15 @@ def stop(ctx):
     ctx.obj["controller"].do_command("stop")
 
 @cli.command()
+@click.pass_context
+def reset(ctx):
+    """Reset error condition on the PCO camera controller.\f
+
+    :param ctx: command execution context
+    """
+    ctx.obj["controller"].do_command("reset")
+
+@cli.command()
 @click.option("--json", "-j", type=click.Path(exists=True),
     help="Specify a JSON file of camera configuration parameters to send")
 @click.argument('vals', nargs=-1, callback=parse_json_args)

--- a/data/tools/python/src/inaira/data/camera_control.py
+++ b/data/tools/python/src/inaira/data/camera_control.py
@@ -149,8 +149,12 @@ class CameraController():
 
         :param params: dictionary of parameters to add to the IPC channel message.
         """
-        reply = self._send_cmd("configure", params)
-        self.logger.info(f"Configuration response: \n{self.format_json(reply)}")
+        response = self._send_cmd("configure", params)
+        if repsonse:
+            self.logger.info(f"Configuration response: \n{self.format_json(response)}")
+        else:
+            self.logger.error("Timeout waiting for response to configuration set request")
+
 
     def _request_config(self):
         """Get the configuration of the PCO camera controller.
@@ -158,8 +162,11 @@ class CameraController():
         This interal method sends a configuration request command to the PCO camera controller and
         displays the response as formatted JSON.
         """
-        reply = self._send_cmd("request_configuration")
-        self.logger.info(f"Config request response: \n{self.format_json(reply)}")
+        response = self._send_cmd("request_configuration")
+        if response:
+            self.logger.info(f"Config request response: \n{self.format_json(response)}")
+        else:
+            self.logger.error("Timeout waiting for response to configuration get request")
 
     def get_status(self):
         """Get the status of the PCO camera controller.
@@ -167,8 +174,11 @@ class CameraController():
         This method send a status request command to the PCO camera controller and displays
         the response as formatted JSON.
         """
-        reply = self._send_cmd("status")
-        self.logger.info(f"Status response: \n{self.format_json(reply)}")
+        response = self._send_cmd("status")
+        if response:
+            self.logger.info(f"Status response: \n{self.format_json(response)}")
+        else:
+            self.logger.error("Timeout waiting for response to status request")
 
     def _send_cmd(self, cmd, params=None):
         """Send an IPC command message to the PCO camera controller.
@@ -184,12 +194,13 @@ class CameraController():
 
         self.ctrl_channel.send(cmd_msg.encode())
 
-        reply = None
+        response = None
         pollevts = self.ctrl_channel.poll(self._timeout_ms)
         if pollevts == IpcChannel.POLLIN:
-            reply = self.ctrl_channel.recv()
+            response_msg = self.ctrl_channel.recv()
+            response = IpcMessage(from_str=response_msg)
 
-        return IpcMessage(from_str=reply)
+        return response
 
     def format_json(self, msg):
         """Format JSON data for display.

--- a/data/tools/python/src/inaira/data/camera_control.py
+++ b/data/tools/python/src/inaira/data/camera_control.py
@@ -150,7 +150,7 @@ class CameraController():
         :param params: dictionary of parameters to add to the IPC channel message.
         """
         response = self._send_cmd("configure", params)
-        if repsonse:
+        if response:
             self.logger.info(f"Configuration response: \n{self.format_json(response)}")
         else:
             self.logger.error("Timeout waiting for response to configuration set request")


### PR DESCRIPTION
This PR implements the frameReceiver decoder plugin to control and read out the PCO camera in odin-data. 